### PR TITLE
Fix default gamemode for the maptype's test run

### DIFF
--- a/Scripts/MapTypes/FlagRushArena.Script.txt
+++ b/Scripts/MapTypes/FlagRushArena.Script.txt
@@ -303,6 +303,11 @@ Void EditAnchorData(Ident _EditedAnchorDataId) {
 	}
 }
 
+Void PlayTestRun() {
+	TMMapType::PlayTestRun_Yield();
+	ReportContext::SetContext(System, ReportContext::C_Context_MapEditor);
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
 // Main
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
@@ -315,6 +320,7 @@ main() {
 	UpdateValidability();
 	
 	HoldLoadingScreen = False;
+	EnableMapTypeStartTest = True; // The maptype will handle the 'StartTest' event
 	
 	CustomEditAnchorData = True;
 	
@@ -354,6 +360,9 @@ main() {
 				}
 				case CMapEditorPluginEvent::Type::EditAnchor: {
 					EditAnchorData(Event.EditedAnchorDataId);
+				}
+				case CMapEditorPluginEvent::Type::StartTest: {
+					PlayTestRun();
 				}
 			}
 		}


### PR DESCRIPTION
When doing a test run of the map type, you would get put into an unknown gamemode that seems to be left over from an older game. This fixes the issue by playing the actual test race gamemode instead.