### PR TITLE
Do not apply handicaps in warmup

### DIFF
--- a/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -1068,7 +1068,10 @@ Void HandleCommands() {
 		switch(Event.Type) {
 			case CSmModeEvent::EType::OnPlayerRequestRespawn:
 			{
-				UnspawnPlayer(Event.Player);
+				declare CSmPlayer EventPlayer = Event.Player;
+				// Need a second variable to prevent a runtime exception
+				// where PendingEvents[X] becomes Null
+				UnspawnPlayer(EventPlayer); 
 			}
 			case CSmModeEvent::EType::OnPlayerAdded:
 			{


### PR DESCRIPTION
I think it was discussed before that having handicaps apply in warmup is particularly confusing, since it seems like you're suddenly fragile out of nowhere. The simplest solution is just to compeletely disable handicaps in warmup.