### PR TITLE
Added a null check for player when pressing ready button

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
@@ -245,6 +245,7 @@ Void Private_HandleUIEvents() {
 		if(Event.CustomEventType == WarmUpReadyUp_UI::C_ReadyEvent_Type) {
 			declare Boolean PlayerIsReady = Event.CustomEventData[0] == "True";
 			declare CSmPlayer Player = GetPlayer(Event.UI);
+			if(Player == Null) continue;
 			G_PlayersReady[Player.User.Login] = PlayerIsReady;
 			Private_AddEvent(C_Event_Type_PlayerReadyChanged, [Player.User.Login, TL::ToText(PlayerIsReady)]);
 		}

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Common.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Common.Script.txt
@@ -9,7 +9,7 @@
 /**
  * Prefixed log.
  */
- Void Log(Text Message) {
+Void Log(Text Message) {
 	declare Boolean FlagRush_Debug for This;
 	if(FlagRush_Debug) log(C_LogPrefix ^ " " ^ Message);
 }


### PR DESCRIPTION
Issue #68

Not sure how this Null Player can even happen. Only saw the Ingame traceback that reaby sent. Afaik, that issue didn't happen since then.

In extreme edge cases it might be, that a ready state change of a player will not be registered by the server, if the Player is Null. Then the player would have to unready and ready again. But that should be an edge case and shouldn't happen (at all actually).