### PR TITLE
Add Time Warnings

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/EventFeed.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/EventFeed.Script.txt
@@ -64,6 +64,7 @@ Void SendMessage(Text String, Text Icon, Vec3 Color) {
 		case "base": SendMessage(String, "ManiaPlanetMainMenu", "IconHome", color);
 		case "flag": SendMessage(String, "UIConstruction_Buttons", "Validate", color);
 		case "info": SendMessage(String, "UICommon64_1", "Info_light", color);
+		case "chrono": SendMessage(String, "UICommon64_1", "Chrono_light", color);
 		default: SendMessage(String, "", "", color);
 	}
 }

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_TimeWarnings.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_TimeWarnings.Script.txt
@@ -15,7 +15,7 @@ declare K_TimeWarnings G_EnabledTimeWarnings;
  * Returns the time until the time limit is reached.
 */
 Integer GetTimeRemaining() {
-	return -(Now - EndTime);
+	return EndTime - Now;
 }
 
 /**

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_TimeWarnings.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_TimeWarnings.Script.txt
@@ -1,0 +1,70 @@
+#Include "Libs/Zrx/ModeLibs/Common/GameplayPhase.Script.txt" as GameplayPhase
+#Include "Libs/Zrx/ModeLibs/Common/EventFeed.Script.txt"		 as EventFeed
+
+#Const	C_BigMessage_Duration					3000
+
+#Struct K_TimeWarnings {
+	Boolean WarmupEndSoon;
+	Boolean RoundEndSoon;
+	Boolean RoundEndVerySoon;
+}
+
+declare K_TimeWarnings G_EnabledTimeWarnings;
+
+/**
+ * Returns the time until the time limit is reached.
+*/
+Integer GetTimeRemaining() {
+	return -(Now - EndTime);
+}
+
+/**
+ * Handles the display of time-related warnings.
+ */
+Void Show() {
+	declare Integer TimeRemaining = GetTimeRemaining();
+	switch (GameplayPhase::Get()) {
+		case GameplayPhase::C_Warmup: {
+			if(TimeRemaining > 0 && TimeRemaining < 5 * 1000 && G_EnabledTimeWarnings.WarmupEndSoon) {
+				G_EnabledTimeWarnings.WarmupEndSoon = False;
+				EventFeed::SendMessage("$f90Warmup ends in 5 seconds!", "chrono");
+			}
+		}
+		case GameplayPhase::C_Round: {
+			if(TimeRemaining < 60 * 1000 && G_EnabledTimeWarnings.RoundEndSoon) {
+				G_EnabledTimeWarnings.RoundEndSoon = False;
+				declare Text Message = "$f9060 seconds remaining!";
+				EventFeed::SendMessage(Message, "chrono");
+				UIManager.UIAll.QueueMessage(C_BigMessage_Duration, 1, CUIConfig::EMessageDisplay::Big, Message, CUIConfig::EUISound::TiePoint, 0);
+			}
+
+			if(TimeRemaining < 30 * 1000 && G_EnabledTimeWarnings.RoundEndVerySoon) {
+				G_EnabledTimeWarnings.RoundEndVerySoon = False;
+				declare Text Message = "$f9030 seconds remaining!";
+				EventFeed::SendMessage(Message, "chrono");
+				UIManager.UIAll.QueueMessage(C_BigMessage_Duration, 1, CUIConfig::EMessageDisplay::Big, Message, CUIConfig::EUISound::TiePoint, 0);
+			}
+		}
+	}
+}
+
+/**
+ * Mark all time warnings as enabled (they will be able to be triggered again).
+ */
+Void EnableAll() {
+	G_EnabledTimeWarnings.WarmupEndSoon = True;
+	G_EnabledTimeWarnings.RoundEndSoon = True;
+	G_EnabledTimeWarnings.RoundEndVerySoon = True;
+}
+
+/**
+ * Mark time warnings as enabled depending on the match timelimit (they will be able to be triggered again).
+ */
+Void EnableWithTimelimit(Integer TotalSeconds) {
+	EnableAll();
+
+	if (TotalSeconds <= 60) {
+		G_EnabledTimeWarnings.RoundEndSoon = False;
+		G_EnabledTimeWarnings.RoundEndVerySoon = False;
+	}
+}

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Header.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Header.Script.txt
@@ -156,11 +156,6 @@ Text GetManialink() {
 				QuadCenterFlag.Visible = !IsTimeLeft;	
 				QuadCenterFlag.Colorize = GetTeamPrimaryColor(FlagCarrierTeam);
 
-				/* Low Time Color */
-				if (IsTimeLeft && RoundTimeLeft / 1000 < 30) {
-					LabelTimeLimit.TextPrefix = "$f00";
-				}
-
 				/* Flag Carrier */
 				LabelFlagCarrier.TextPrefix = "$" ^ CL::RgbToHex3(GetTeamPrimaryColor(FlagCarrierTeam));
 				LabelFlagCarrier.Value = Net_FlagRush_FlagCarrierName;
@@ -178,6 +173,12 @@ Text GetManialink() {
 						LabelTimeLimit.Value = "Overtime";
 						LabelTimeLimit.Visible = True;
 						QuadCenterFlag.Visible = False;
+					}
+					case {{{GameplayPhase::C_Round}}}: {
+						/* Low Time Color */
+						if (IsTimeLeft && RoundTimeLeft / 1000 < 30) {
+							LabelTimeLimit.TextPrefix = "$f00";
+						}
 					}
 				}
 				

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Header.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Header.Script.txt
@@ -156,6 +156,11 @@ Text GetManialink() {
 				QuadCenterFlag.Visible = !IsTimeLeft;	
 				QuadCenterFlag.Colorize = GetTeamPrimaryColor(FlagCarrierTeam);
 
+				/* Low Time Color */
+				if (IsTimeLeft && RoundTimeLeft / 1000 < 30) {
+					LabelTimeLimit.TextPrefix = "$f00";
+				}
+
 				/* Flag Carrier */
 				LabelFlagCarrier.TextPrefix = "$" ^ CL::RgbToHex3(GetTeamPrimaryColor(FlagCarrierTeam));
 				LabelFlagCarrier.Value = Net_FlagRush_FlagCarrierName;

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -24,6 +24,7 @@
 #Include "Libs/Zrx/ModeLibs/FlagRush/FlagRush_Teams.Script.txt"							as FlagRush_Teams
 #Include "Libs/Zrx/ModeLibs/FlagRush/FlagRush_FlagState.Script.txt"					as FlagState
 #Include "Libs/Zrx/ModeLibs/FlagRush/FlagRush_MatchEvaluation.Script.txt"		as MatchEvaluation
+#Include "Libs/Zrx/ModeLibs/FlagRush/FlagRush_TimeWarnings.Script.txt"			as TimeWarnings
 
 /* UI */
 #Include "Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt"			as FlagRush_UI
@@ -197,6 +198,7 @@ FlagRush_Common::Log("Start Map");
 Users_SetNbFakeUsers(C_Debug_NbFakeUsers.X, C_Debug_NbFakeUsers.Y);
 
 FlagRush_UI::UpdateScores();
+TimeWarnings::EnableAll();
 
 EventFeed::SendMessage("Map Start", "info");
 MB_Sleep(5000);
@@ -222,6 +224,7 @@ FlagRush_UI::UpdateDossards();
 FlagRush_Common::Log("Start Round");
 
 FlagRush_UI::UpdateScores();
+TimeWarnings::EnableWithTimelimit(S_RoundTimeLimitSeconds);
 
 declare Text Message = "Round Start";
 EventFeed::SendMessage(Message, "info");
@@ -410,6 +413,7 @@ HandleEvents();
 HandleCommands();
 HandleModeSettingsUpdate();
 
+TimeWarnings::Show();
 CheckRoundEndConditions();
 
 if(G_PauseRequested) {
@@ -1152,6 +1156,7 @@ Void ExecWarmUp() {
 		HandleWarmUpEvents();
 		HandleCommands();
 		HandleModeSettingsUpdate();
+		TimeWarnings::Show();
 	}
 	
 	// End WarmUp


### PR DESCRIPTION
See issue #69.

- Messages and event feeds broadcasted at 60 and 30 seconds remaining (unless round timelimit setting <= 60). Same thing for warmup 5 seconds before starting (only event feed message).

- Red timer when below 30 seconds. Couldn't make the timer blinking due to limited updates on the scoreboard (even when disabled, it didn't look too great).