### PR TITLE
Fix: Always resetting respawn timer when eliminated by offzone or squished by moving blocks

### DIFF
--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -33,7 +33,7 @@
 
 /* Constants */
 #Const	CompatibleMapTypes						"Trackmania\\FlagRushArena,FlagRushArena"
-#Const	Version												"1.1.1"
+#Const	Version												"1.1.2"
 #Const	ScriptName										"Modes/TrackMania/FlagRush.Script.txt"
 
 #Const	C_SpawnAnimDuration						1500

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -802,16 +802,16 @@ Void FlagRush_UnspawnPlayers() {
  */
 Void SpawnPlayers() {
 	foreach (Player in Players) {
+		declare netwrite Integer Net_SpawnDate for Player;
 		if (Player.Armor <= 0) {		// If Player has no armor, unspawn first (for example Offzone hit)
 			if(GameplayPhase::Get() != GameplayPhase::C_Warmup) {
-				declare netwrite Integer Net_SpawnDate for Player;
 				Net_SpawnDate = Now + ML::NearestInteger(S_RespawnDelay * 1000);
+				Player.Armor = 1;
 			}
 			FlagRush_UnspawnPlayer(Player);	// Has to be done here, since Player in OnArmorEmpty Event in Null			
 		}
 		
 		// Spawn unspawned players
-		declare netwrite Integer Net_SpawnDate for Player;
 		if (Player.SpawnStatus == CSmPlayer::ESpawnStatus::NotSpawned && Net_SpawnDate <= Now) {
 			InitPlayer(Player);
 			declare CMapLandmark SpawnLandmark = FlagRush_Map::GetSpawn(Player);

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -538,7 +538,6 @@ Void CheckRoundEndConditions() {
 Void InitPlayer(CSmPlayer Player) {
 	Player.TrustClientSimu = True;
 	Player.UseCrudeExtrapolation = False;
-	Player.Armor = 1;
 	declare Integer PreviousClan for Player;
 	
 	SetPlayerClan(Player, Player.RequestedClan);
@@ -803,12 +802,11 @@ Void FlagRush_UnspawnPlayers() {
 Void SpawnPlayers() {
 	foreach (Player in Players) {
 		declare netwrite Integer Net_SpawnDate for Player;
-		if (Player.Armor <= 0) {		// If Player has no armor, unspawn first (for example Offzone hit)
+		if (Player.Armor <= 0 && Player.SpawnStatus == CSmPlayer::ESpawnStatus::Spawned) {		// If Player has no armor, unspawn first (for example Offzone hit)
 			if(GameplayPhase::Get() != GameplayPhase::C_Warmup) {
 				Net_SpawnDate = Now + ML::NearestInteger(S_RespawnDelay * 1000);
-				Player.Armor = 1;
 			}
-			FlagRush_UnspawnPlayer(Player);	// Has to be done here, since Player in OnArmorEmpty Event in Null			
+			FlagRush_UnspawnPlayer(Player);	// Has to be done here, since Player in OnArmorEmpty Event in Null
 		}
 		
 		// Spawn unspawned players

--- a/README.md
+++ b/README.md
@@ -118,3 +118,6 @@ The project is licensed under the [MIT License](LICENSE).
 
 ## 1.1.1
 * Fixed an small issue with the radar not displaying some players correctly when in spectator
+
+## 1.1.2
+* Fixed an issue with the respawn timer constantly resetting when falling into offzone


### PR DESCRIPTION
It's the issue iwth always resetting respawn timers that we already had. I thought we fixed it, but apparently we didn't.
This should do the trick though.
Important bugfix. Affected maps are for example spike valley and Terraformer. I can't think of other maps who have offzone or moving blocks right now.