### PR TITLE
Warm up ready up pad shortcut changed from select to R3

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
@@ -204,7 +204,7 @@ Void Start() {
 	Layers::Create(WarmUpReadyUp_UI::C_ManialinkName, WarmUpReadyUp_UI::GetManialink());
 	Layers::SetType(WarmUpReadyUp_UI::C_ManialinkName, CUILayer::EUILayerType::Normal);
 	Layers::Attach(WarmUpReadyUp_UI::C_ManialinkName);
-	UIManager.UIAll.SendChat("""$f90Warmup!$fff Ready up by clicking the "Ready"-Button or pressing F7 / """);
+	UIManager.UIAll.SendChat("""$f90Warmup!$fff Ready up by clicking the "Ready"-Button or pressing F7 / """);
 }
 
 /**

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
@@ -204,7 +204,7 @@ Void Start() {
 	Layers::Create(WarmUpReadyUp_UI::C_ManialinkName, WarmUpReadyUp_UI::GetManialink());
 	Layers::SetType(WarmUpReadyUp_UI::C_ManialinkName, CUILayer::EUILayerType::Normal);
 	Layers::Attach(WarmUpReadyUp_UI::C_ManialinkName);
-	UIManager.UIAll.SendChat("""$f90Warmup!$fff Ready up by clicking the "Ready"-Button or pressing F7 / """);
+	UIManager.UIAll.SendChat("""$f90Warmup!$fff Ready up by clicking the "Ready"-Button or pressing F7 / """);
 }
 
 /**

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp_UI.Script.txt
@@ -91,7 +91,7 @@ Text GetManialink() {
 				}
 
 				foreach(InputEvent in Input.PendingEvents) {
-					if(InputEvent.Pad != Null && InputEvent.Pad.ButtonEvents.exists(CInputPad::EButton::View)) {
+					if(InputEvent.Pad != Null && InputEvent.Pad.ButtonEvents.exists(CInputPad::EButton::LeftStick)) {
 						SetReady(!Ready);
 					}
 				}

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp_UI.Script.txt
@@ -91,7 +91,7 @@ Text GetManialink() {
 				}
 
 				foreach(InputEvent in Input.PendingEvents) {
-					if(InputEvent.Pad != Null && InputEvent.Pad.ButtonEvents.exists(CInputPad::EButton::LeftStick)) {
+					if(InputEvent.Pad != Null && InputEvent.Pad.ButtonEvents.exists(CInputPad::EButton::RightStick)) {
 						SetReady(!Ready);
 					}
 				}


### PR DESCRIPTION
Many players use Select/Menu für another action, like the ingame menu or scoreboard. R3 should have way less keybind clashes.