### PR TITLE
Fix exit button in local test

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Menu.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Menu.Script.txt
@@ -443,6 +443,7 @@ Text GetManialink() {
 			}
 			case "Quit": {
 				Playground.QuitServer(False);
+				CloseInGameMenu(CMlScriptIngame::EInGameMenuResult::Quit);
 			}
 		}
 	}


### PR DESCRIPTION
Here's a patch you were looking up for 👀

When testing a flagrush map in local mode (with the gamemode), exiting back to the editor is not possible because it can't actually quit the server. this should fix that behaviour. (untested on servers, but they should not be affected)