### PR TITLE
Update Layer handling (updates instead of re-inits)

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt
@@ -31,7 +31,6 @@
 #Const C_LayerName_Dialog							"Layer_FlagRush_Dialog"
 #Const C_LayerName_ScoresTable				"Layer_FlagRush_ScoresTable"
 #Const C_LayerName_ScoresHeader				"Layer_FlagRush_ScoresHeader"
-#Const C_LayerName_RoundUI						"Layer_FlagRush_RoundUI"
 #Const C_LayerName_MVP								"Layer_FlagRush_MVP"
 #Const C_LayerName_Markers						"Layer_FlagRush_Markers"
 #Const C_LayerName_Menu								"Layer_FlagRush_Menu"
@@ -60,22 +59,55 @@
 declare CUIConfigMarker G_FlagMarker;
 
 /**
- * Puts a marker above every flag spawn.
+ * Destroys all the FlagRush UI layers.
  */
-Void InitFlagSpawnMarkers() {
-	// Create a marker for each spawn
-	foreach(I => FlagSpawn in FlagRush_Map::GetFlagSpawns()) {
-		declare Marker = UIManager.UIAll.AddMarker(FlagSpawn);
-		Marker.HudVisibility = CUIConfigMarker::EHudVisibility::WhenInFrustum;
-		Marker.ManialinkFrameId = "marker-flag-spawn-"^I;
-		Marker.Box = <0., 3.3, 0.>;
-	}
+Void Destroy() {
+	Layers::Destroy(C_LayerName_Dialog);
+	Layers::Destroy(C_LayerName_ScoresTable);
+	Layers::Destroy(C_LayerName_ScoresHeader);
+	Layers::Destroy(C_LayerName_MVP);
+	Layers::Destroy(C_LayerName_Markers);
+	Layers::Destroy(C_LayerName_Menu);
+	Layers::Destroy(C_LayerName_Feed);
+	Layers::Destroy(C_LayerName_Flash);
+	Layers::Destroy(C_LayerName_Sound);
+	Layers::Destroy(C_LayerName_Spectator);
+	Layers::Destroy(C_LayerName_Respawn);
+	Layers::Destroy(C_LayerName_ModeCommands);
+	Layers::Destroy(C_LayerName_Radar);
+}
+
+/**
+ * Changes the flag markers visibility to "Always".
+ */
+Void ShowFlagMarker() {
+	G_FlagMarker.HudVisibility = CUIConfigMarker::EHudVisibility::Always;
+}
+
+/**
+ * Changes the flag markers visibility to "Never".
+ */
+Void HideFlagMarker() {
+	G_FlagMarker.HudVisibility = CUIConfigMarker::EHudVisibility::Never;
 }
 
 /**
  * Destroys the old flag marker and places a new one at the corresponding location.
  */
- Void InitFlagMarker() {
+ Void UpdateFlagMarker() {
+	// Remove old Flag marker
+	// IMPORTANT: Cannot remove G_FlagMarker from UIAll, because UIAll.Markers more or less references a list of UI.Markers for all UIs!
+	// Trying to use UIAll.RemoveMarker(G_FlagMarker) after a new map loaded will lead to an access error for a specific UI ("Element not found in Array").
+	// Fortunately, removing corresponding markers from every specific UI individually apparently also removes it from UIAll.
+	foreach (UI in UIManager.UI) {
+		foreach (Marker in UI.Markers) {
+			if(Marker.ManialinkFrameId == FlagRush_UIMarkers::C_FlagMarkerFrameId) {
+				UI.RemoveMarker(Marker);
+				break;
+			}
+		}
+	}
+
 	// Create a new marker
 	declare CSmPlayer FlagCarrierPlayer = FlagState::GetFlagCarrierPlayer();
 	if (FlagCarrierPlayer != Null) {
@@ -89,57 +121,37 @@ Void InitFlagSpawnMarkers() {
 		G_FlagMarker.Box = C_FlagMarker_Box_Position;
 	}
 
-	G_FlagMarker.ManialinkFrameId = "marker-flag";
-	G_FlagMarker.HudVisibility = CUIConfigMarker::EHudVisibility::Always;
+	G_FlagMarker.ManialinkFrameId = FlagRush_UIMarkers::C_FlagMarkerFrameId;
+	ShowFlagMarker();
 }
 
 /**
- * Updates the flag marker and puts it at the right position.
- * Actually does the same as InitFlagMarker.
- * This exists to prevent confusion when InitFlagMarker would be called in the middle of a round/event.
+ * Changes all flag spawn marker visibilities to "WhenInFrustum".
  */
-Void UpdateFlagMarker() { InitFlagMarker(); }
-
-/**
- * Send data about the flag carrier, i.e. name and clan to the UIs via netwrite
- */
- Void UpdateFlagCarrierNetData() {
-	declare FlagCarrierPlayer = FlagState::GetFlagCarrierPlayer();
-
-	// Carrier Clan Index (for color)
-	declare netwrite Integer Net_FlagRush_FlagCarrierClan for Teams[0];
-	if (FlagCarrierPlayer == Null) Net_FlagRush_FlagCarrierClan = 0;
-	else Net_FlagRush_FlagCarrierClan = FlagCarrierPlayer.CurrentClan;
-
-	// Carrier name and login
-	declare netwrite Text Net_FlagRush_FlagCarrierName for Teams[0];
-	declare netwrite Text Net_FlagRush_FlagCarrierLogin for Teams[0];
-	Net_FlagRush_FlagCarrierLogin = "";
-	if (FlagCarrierPlayer != Null) {
-		Net_FlagRush_FlagCarrierName = FlagCarrierPlayer.User.Name;
-		Net_FlagRush_FlagCarrierLogin = FlagCarrierPlayer.User.Login;
-	}
-	else if (FlagState::Get().Landmark != Null) Net_FlagRush_FlagCarrierName = C_FlagCarrierName_Spawn;
-	else Net_FlagRush_FlagCarrierName = C_FlagCarrierName_Dropped;
-
-	// Flag Position
-	declare netwrite Vec3 Net_FlagRush_FlagPosition for Teams[0];
-	Net_FlagRush_FlagPosition = FlagState::Get().Position;
+Void ShowFlagSpawnMarkers() {
+	foreach (Marker in UIManager.UIAll.Markers)
+		if(TL::StartsWith(FlagRush_UIMarkers::C_FlagSpawnMarkerFrameIdPrefix, Marker.ManialinkFrameId))
+			Marker.HudVisibility = CUIConfigMarker::EHudVisibility::WhenInFrustum;
 }
 
 /**
- * Creates Markers for the bases and the flag for each player.
+ * Changes all flag spawn marker visibilities to "Never".
  */
-Void InitMarkers() {
-	declare Boolean IsWarmup = GameplayPhase::Get() == GameplayPhase::C_Warmup;
+Void HideFlagSpawnMarkers() {
+	foreach (Marker in UIManager.UIAll.Markers)
+		if(TL::StartsWith(FlagRush_UIMarkers::C_FlagSpawnMarkerFrameIdPrefix, Marker.ManialinkFrameId))
+			Marker.HudVisibility = CUIConfigMarker::EHudVisibility::Never;
+}
 
+/**
+ * Creates Markers for the bases and the flag.
+ */
+Void UpdateMapMarkers() {
 	// Clear old markers
 	UIManager.UIAll.ClearMarkers();
 
-	// Create Layer for all UIs
-	Layers::Create(C_LayerName_Markers, FlagRush_UIMarkers::GetManialink());
-	Layers::SetType(C_LayerName_Markers, CUILayer::EUILayerType::Markers);
-	Layers::Attach(C_LayerName_Markers);
+	// Update Layer
+	Layers::Update(C_LayerName_Markers, FlagRush_UIMarkers::GetManialink());
 
 	// Create Markers for the Bases
 	for(Clan, 1, 2) {
@@ -151,36 +163,31 @@ Void InitMarkers() {
 		}
 	}
 
-	// Create Markers for the flag and flagspawns
-	if (IsWarmup) {
-		InitFlagSpawnMarkers();
-	} else {
-		InitFlagMarker();
+	// Create a marker for each flag spawn
+	foreach(I => FlagSpawn in FlagRush_Map::GetFlagSpawns()) {
+		declare Marker = UIManager.UIAll.AddMarker(FlagSpawn);
+		Marker.ManialinkFrameId = FlagRush_UIMarkers::C_FlagSpawnMarkerFrameIdPrefix ^ I;
+		Marker.Box = <0., 3.3, 0.>;
 	}
+	HideFlagSpawnMarkers();
+
+	// Main flag marker
+	UpdateFlagMarker();
 }
 
 /**
  * Creates the radar with markers for all players and bases.
  */
-Void InitRadar() {
-	declare FlagRush_UIRadar::K_Config Config = FlagRush_UIRadar::K_Config {
-		Scale = 0.35,
-		MarkerScale = 1.5,
-		Position = <135., -65.>,
-		Zoom = 0.35,
-		BackgroundOpacity = 0.7,
-		DetailOpacity = 0.1};
-	FlagRush_UIRadar::SetConfig(Config);
-
-	Layers::Create(C_LayerName_Radar, FlagRush_UIRadar::GetManialink());
-	Layers::SetType(C_LayerName_Radar, CUILayer::EUILayerType::Normal);
-	Layers::Attach(C_LayerName_Radar);
+Void UpdateRadar() {
+	Layers::Update(C_LayerName_Radar, FlagRush_UIRadar::GetManialink());
 }
 
 /**
- * Creates the UI Layers and initializes the markers for each player.
+ * Creates the UI Layers and initializes the markers.
  */
 Void Init(Text FlagRush_Version) {
+	Destroy();
+
 	// Scores header
 	Layers::Create(C_LayerName_ScoresHeader, FlagRush_UIHeader::GetManialink());
 	Layers::SetType(C_LayerName_ScoresHeader, CUILayer::EUILayerType::Normal);
@@ -241,10 +248,50 @@ Void Init(Text FlagRush_Version) {
 	}
 
 	// Markers
-	InitMarkers();
+	Layers::Create(C_LayerName_Markers, FlagRush_UIMarkers::GetManialink());
+	Layers::SetType(C_LayerName_Markers, CUILayer::EUILayerType::Markers);
+	Layers::Attach(C_LayerName_Markers);
 
 	// Radar
-	InitRadar();
+	declare FlagRush_UIRadar::K_Config Config = FlagRush_UIRadar::K_Config {
+		Scale = 0.35,
+		MarkerScale = 1.5,
+		Position = <135., -65.>,
+		Zoom = 0.35,
+		BackgroundOpacity = 0.7,
+		DetailOpacity = 0.1
+	};
+	FlagRush_UIRadar::SetConfig(Config);
+	Layers::Create(C_LayerName_Radar, FlagRush_UIRadar::GetManialink());
+	Layers::SetType(C_LayerName_Radar, CUILayer::EUILayerType::Normal);
+	Layers::Attach(C_LayerName_Radar);
+}
+
+/**
+ * Send data about the flag carrier, i.e. name and clan to the UIs via netwrite
+ */
+ Void UpdateFlagCarrierNetData() {
+	declare FlagCarrierPlayer = FlagState::GetFlagCarrierPlayer();
+
+	// Carrier Clan Index (for color)
+	declare netwrite Integer Net_FlagRush_FlagCarrierClan for Teams[0];
+	if (FlagCarrierPlayer == Null) Net_FlagRush_FlagCarrierClan = 0;
+	else Net_FlagRush_FlagCarrierClan = FlagCarrierPlayer.CurrentClan;
+
+	// Carrier name and login
+	declare netwrite Text Net_FlagRush_FlagCarrierName for Teams[0];
+	declare netwrite Text Net_FlagRush_FlagCarrierLogin for Teams[0];
+	Net_FlagRush_FlagCarrierLogin = "";
+	if (FlagCarrierPlayer != Null) {
+		Net_FlagRush_FlagCarrierName = FlagCarrierPlayer.User.Name;
+		Net_FlagRush_FlagCarrierLogin = FlagCarrierPlayer.User.Login;
+	}
+	else if (FlagState::Get().Landmark != Null) Net_FlagRush_FlagCarrierName = C_FlagCarrierName_Spawn;
+	else Net_FlagRush_FlagCarrierName = C_FlagCarrierName_Dropped;
+
+	// Flag Position
+	declare netwrite Vec3 Net_FlagRush_FlagPosition for Teams[0];
+	Net_FlagRush_FlagPosition = FlagState::Get().Position;
 }
 
 /**

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Markers.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Markers.Script.txt
@@ -3,6 +3,9 @@
 #Include	"Libs/Zrx/ModeLibs/FlagRush/UI/UIShared.Script.txt"	as UIShared
 #Include "Libs/Zrx/ModeLibs/FlagRush/FlagRush_Map.Script.txt"	as FlagRush_Map
 
+#Const C_FlagMarkerFrameId						"marker-flag"
+#Const C_FlagSpawnMarkerFrameIdPrefix	"marker-flag-spawn-"
+
 Text GetManialink() {
 
 	declare Text BasesFrameInstancesXml;
@@ -17,7 +20,7 @@ Text GetManialink() {
 	declare Text FlagSpawnMarkerFrameInstancesXml;
 	for(I, 0, FlagRush_Map::GetFlagSpawns().count - 1) {
 		FlagSpawnMarkerFrameInstancesXml ^= """
-		<frameinstance modelid="model-marker-flag" id="marker-flag-spawn-{{{I}}}" scale="0.7"/>
+		<frameinstance modelid="model-marker-flag" id="{{{C_FlagSpawnMarkerFrameIdPrefix ^ I}}}" scale="0.7"/>
 		""";
 	}
 
@@ -46,7 +49,7 @@ Text GetManialink() {
 
 		{{{BasesFrameInstancesXml}}}
 
-		<frameinstance modelid="model-marker-flag" id="marker-flag"/>
+		<frameinstance modelid="model-marker-flag" id="{{{ C_FlagMarkerFrameId }}}"/>
 
 		{{{FlagSpawnMarkerFrameInstancesXml}}}
 
@@ -89,7 +92,7 @@ Text GetManialink() {
 					Team2BaseMarkerFrames.add(FrameMarkerBase2);
 				}
 
-				declare CMlFrame FrameMarkerFlag = (Page.GetFirstChild("marker-flag") as CMlFrame);
+				declare CMlFrame FrameMarkerFlag = (Page.GetFirstChild("{{{ C_FlagMarkerFrameId }}}") as CMlFrame);
 				declare CMlFrame FrameGauge = (Page.GetFirstChild("gauge-frame") as CMlFrame);
 				declare CMlQuad QuadMarkerFlag = (FrameMarkerFlag.GetFirstChild("quad-flag") as CMlQuad);
 				declare CMlQuad QuadFlagUp = (FrameMarkerFlag.GetFirstChild("up") as CMlQuad);

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -200,6 +200,9 @@ ModeCommands::AddQuickCommand(C_Command_Pause, "UICommon64_1", "Pause_light");
 ModeCommands::AddQuickCommand(C_Command_SkipMap, "UICommon64_1", "GoLastFrame_light");
 ModeCommands::AddQuickCommand(C_Command_ResetFlag, "UICommon64_1", "Flag_light");
 HandleModeSettingsUpdate();
+
+// UI
+FlagRush_UI::Init(Version);
 ***
 
 ***Match_LoadItems***
@@ -218,8 +221,8 @@ EventFeed::SendMessage("Match Start", "info");
 FlagRush_Map::InitLandmarks();
 Map::SetDefaultStart(FlagRush_Map::GetSpawn(1));
 FlagState::SetAtLandmark(FlagRush_Map::GetDefaultFlagSpawn());
+FlagRush_UI::UpdateMapMarkers();
 
-FlagRush_UI::Init(Version);
 InitPlayers();
 FlagRush_Teams::Init();
 FlagRush_UI::UpdateDossards();
@@ -251,7 +254,6 @@ if(S_UseWarmUp) {
 G_RoundValid = True;
 GameplayPhase::Set(GameplayPhase::C_Round);
 InitPlayers();
-FlagRush_UI::InitMarkers();
 FlagRush_Teams::Init();
 FlagRush_UI::UpdateDossards();
 ***
@@ -421,14 +423,17 @@ if(CheckMatchEndConditions())
 	FlagRush_UI::ToggleMVP(False);
 	MB_StopMatch();
 }
-
-Layers::DestroyAll();
 ***
 
 ***Match_EndMatch***
 ***
 FlagRush_Common::Log("Match End");
 EventFeed::SendMessage("Match End", "info");
+***
+
+***Match_EndServer***
+***
+FlagRush_UI::Destroy();
 ***
 
 ***Match_PlayLoop***
@@ -503,7 +508,7 @@ Void SendWelcomeMessage(CSmPlayer Player) {
 
 Void CheckPlayercountChanged() {
 	if (Players.count != G_LastPlayersCount) {
-		FlagRush_UI::InitRadar();
+		FlagRush_UI::UpdateRadar();
 		FlagRush_Teams::Init();
 
 		G_LastPlayersCount = Players.count;
@@ -1139,7 +1144,7 @@ Void HandleEvents() {
 				SendWelcomeMessage(Event.Player);
 				FlagRush_Teams::Init();
 				FlagRush_UI::UpdateDossards();
-				FlagRush_UI::InitRadar();
+				FlagRush_UI::UpdateRadar();
 			}
 
 			case CSmModeEvent::EType::OnPlayerRemoved: {
@@ -1148,7 +1153,7 @@ Void HandleEvents() {
 				if(FlagState::Get().Carrier == Event.User) DropFlag();
 				FlagRush_Teams::Init();
 				FlagRush_UI::UpdateDossards();
-				FlagRush_UI::InitRadar();
+				FlagRush_UI::UpdateRadar();
 			}
 		}
 	}
@@ -1315,10 +1320,10 @@ Void HandleCommands() {
 			case CSmModeEvent::EType::OnPlayerAdded: {
 				InitPlayer(Event.Player);
 				SendWelcomeMessage(Event.Player);
-				FlagRush_UI::InitRadar();
+				FlagRush_UI::UpdateRadar();
 			}
 			case CSmModeEvent::EType::OnPlayerRemoved: {
-				FlagRush_UI::InitRadar();
+				FlagRush_UI::UpdateRadar();
 			}
 			case CSmModeEvent::EType::OnPlayerRequestRespawn: {
 				declare CSmPlayer EventPlayer = Event.Player;
@@ -1366,7 +1371,8 @@ Void ExecWarmUp() {
 
 	InitPlayers();
 	FlagRush_Teams::Init();
-	FlagRush_UI::InitMarkers();
+	FlagRush_UI::ShowFlagSpawnMarkers();
+	FlagRush_UI::HideFlagMarker();
 	FlagRush_UI::UpdateDossards();
 
 	StartTime = Now;
@@ -1405,7 +1411,8 @@ Void ExecWarmUp() {
 	// Cleanup
 	GameplayPhase::Set(PreviousGameplayPhase);
 	UIManager.UIAll.UISequence = PrevUISequence;
-	FlagRush_UI::InitMarkers();
+	FlagRush_UI::HideFlagSpawnMarkers();
+	FlagRush_UI::ShowFlagMarker();
 	foreach(Player in Players) {
 		UnspawnPlayer(Player);
 	}


### PR DESCRIPTION
We've been reinitializing layers quite often, for example for the radar or markers. I changed it to update the layer manialinks instead, using the Update function from the library.

Also we don't need to init the whole UI at every map init and destroy it at every map end. Instead init once on ServerStart and Destroy on ServerEnd.

I changed the handling of how the flag spawn markers. There are now functions to explicitly hide the flag spawn markers and and the main flag marker. All markers (Bases, Flag spawns, Flag) are initialized once at the InitMap.