### PR TITLE
Remove trigrams

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt
@@ -46,11 +46,6 @@
 #Const C_FlagCarrierName_Dropped 	"Dropped"
 #Const C_FlagCarrierName_Spawn		"Spawn"
 
-#Const C_Trigram_FlagCarrier			"FLG"
-#Const C_Trigram_FlagOwnTeam 			"OWN"
-#Const C_Trigram_FlagOpponent			"OPP"
-#Const C_Trigram_FlagNoCarrier		"   "
-
 #Const C_FlagMarker_Box_Player		<0., 1., 0.>
 #Const C_FlagMarker_Box_Landmark	<0., 3., 0.>
 #Const C_FlagMarker_Box_Position	<0., 0., 0.>
@@ -245,40 +240,6 @@ Void Init(Text FlagRush_Version) {
 
 	// Radar
 	InitRadar();
-}
-
-/**
- * Updates the dossard for a specific player.
- */
- Void UpdateDossard(CSmPlayer Player) {
-	if (Player.CurrentClan <= 0) return;
-
-	// Color
-	Player.Dossard_Color = FlagRush_Teams::GetTeamDossardColor(Player.CurrentClan-1);
-	Player.Dossard_Number = "0" ^ Player.CurrentClan;
-
-	// Text
-	declare FlagCarrierPlayer = FlagState::GetFlagCarrierPlayer();
-	if (FlagCarrierPlayer != Null) {
-		if(FlagCarrierPlayer == Player) {
-			Player.Dossard_Trigram = C_Trigram_FlagCarrier;
-		} else if (FlagCarrierPlayer.CurrentClan == Player.CurrentClan) {
-			Player.Dossard_Trigram = C_Trigram_FlagOwnTeam;
-		} else {
-			Player.Dossard_Trigram = C_Trigram_FlagOpponent;
-		}
-	} else {
-		Player.Dossard_Trigram = C_Trigram_FlagNoCarrier;
-	}
-}
-
-/**
- * Updates the dossard for all players.
- */
-Void UpdateDossards() {
-	foreach (Player in Players) {
-		UpdateDossard(Player);
-	}
 }
 
 /**

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -589,6 +589,8 @@ Boolean CheckMatchEndConditions() {
 Void InitPlayer(CSmPlayer Player) {
 	Player.TrustClientSimu = True;
 	Player.UseCrudeExtrapolation = !UsePvPCollisions && S_UseCrudeExtrapolation;
+	Player.Dossard_Number = "  ";
+	Player.Dossard_Color = <1., 1., 1.>;
 	declare Integer PreviousClan for Player;
 	SetPlayerClan(Player, Player.RequestedClan);
 

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -222,7 +222,6 @@ FlagState::SetAtLandmark(FlagRush_Map::GetDefaultFlagSpawn());
 FlagRush_UI::Init(Version);
 InitPlayers();
 FlagRush_Teams::Init();
-FlagRush_UI::UpdateDossards();
 SetEndTime(-1);
 SetFlagPosition(FlagRush_Map::GetDefaultFlagSpawn(), Now);
 
@@ -253,7 +252,6 @@ GameplayPhase::Set(GameplayPhase::C_Round);
 InitPlayers();
 FlagRush_UI::InitMarkers();
 FlagRush_Teams::Init();
-FlagRush_UI::UpdateDossards();
 ***
 
 ***Match_StartRound***
@@ -600,7 +598,6 @@ Void InitPlayer(CSmPlayer Player) {
 
 	if (Player.RequestedClan != PreviousClan) {
 		FlagRush_Teams::Init();
-		FlagRush_UI::UpdateDossards();
 	}
 
 	PreviousClan = Player.RequestedClan;
@@ -688,7 +685,6 @@ Void OnFlagPositionChanged(Integer PickupableDate) {
 	FlagState::SetPickupableDate(PickupableDate);
 	FlagRush_UI::UpdateFlagMarker();
 	FlagRush_UI::UpdateFlagCarrierNetData();
-	FlagRush_UI::UpdateDossards();
 }
 
 Void SetFlagPosition(CMapLandmark FlagSpawn, Integer PickupableDate) {
@@ -887,7 +883,6 @@ Void SpawnPlayers() {
 			declare CMapLandmark SpawnLandmark = FlagRush_Map::GetSpawn(Player);
 			if (SpawnLandmark != Null) {
 				SpawnPlayer(Player, Player.CurrentClan, 1, SpawnLandmark.PlayerSpawn, Now + C_SpawnAnimDuration);
-				FlagRush_UI::UpdateDossard(Player);
 				Net_SpawnDate = 0;
 			}
 		}
@@ -977,7 +972,6 @@ Void HandleModeSettingsUpdate() {
 		// FlagRush_Teams::SetTeam2ColorHexOverride(S_Team2Color);
 		FlagRush_Teams::UseClubTags(S_UseClubTags);
 		FlagRush_Teams::Init();
-		FlagRush_UI::UpdateDossards();
 	}
 
 	UpdateCriticalSettings();
@@ -1138,7 +1132,6 @@ Void HandleEvents() {
 			case CSmModeEvent::EType::OnPlayerAdded: {
 				SendWelcomeMessage(Event.Player);
 				FlagRush_Teams::Init();
-				FlagRush_UI::UpdateDossards();
 				FlagRush_UI::InitRadar();
 			}
 
@@ -1147,7 +1140,6 @@ Void HandleEvents() {
 				// This is the reason why Carrier in FlagState is not CSmPlayer
 				if(FlagState::Get().Carrier == Event.User) DropFlag();
 				FlagRush_Teams::Init();
-				FlagRush_UI::UpdateDossards();
 				FlagRush_UI::InitRadar();
 			}
 		}
@@ -1367,7 +1359,6 @@ Void ExecWarmUp() {
 	InitPlayers();
 	FlagRush_Teams::Init();
 	FlagRush_UI::InitMarkers();
-	FlagRush_UI::UpdateDossards();
 
 	StartTime = Now;
 	SetEndTime(-1);


### PR DESCRIPTION
From a suggestion on the discord. The change is to remove the "own", "opp" and "flg" trigrams to let players use their own. There was little feedback over this suggestion, and considering it didn't gather much attention, I concluded that the current trigrams were not much in use, so we'd rather let the player ones exist instead.