### PR TITLE
fix player flags scored sync

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Common.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Common.Script.txt
@@ -6,7 +6,7 @@
 
 #Const	C_Telemetry_Key_FlagsScored				"FlagsScored"
 #Const	C_Telemetry_Key_FlagsStolen				"FlagsStolen"
-#Const	C_Telemerty_Key_FlagScoreAssists	"FlagScoreAssists"
+#Const	C_Telemetry_Key_FlagScoreAssists	"FlagScoreAssists"
 
 #Const	C_SpawnAnimDuration 1500
 

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_RpcEvents.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_RpcEvents.Script.txt
@@ -295,9 +295,9 @@ K_Rpc_PlayerScore ScoreToRpcPlayerScore(CSmScore Score) {
 		FlagsStolenRound = Telemetry::GetPlayerRoundInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagsStolen),
 		FlagsStolenMap = Telemetry::GetPlayerMapInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagsStolen),
 		FlagsStolenMatch = Telemetry::GetPlayerMatchInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagsStolen),
-		AssistsRound = Telemetry::GetPlayerRoundInteger(Score, FlagRush_Common::C_Telemerty_Key_FlagScoreAssists),
-		AssistsMap = Telemetry::GetPlayerMapInteger(Score, FlagRush_Common::C_Telemerty_Key_FlagScoreAssists),
-		AssistsMatch = Telemetry::GetPlayerMatchInteger(Score, FlagRush_Common::C_Telemerty_Key_FlagScoreAssists)
+		AssistsRound = Telemetry::GetPlayerRoundInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagScoreAssists),
+		AssistsMap = Telemetry::GetPlayerMapInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagScoreAssists),
+		AssistsMatch = Telemetry::GetPlayerMatchInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagScoreAssists)
 	};
 }
 

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt
@@ -336,11 +336,11 @@ Void UpdateScore(CSmScore Score) {
 		= Telemetry::GetPlayerRoundInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagsStolen);
 
 	Net_FlagRush_FlagsAssists_Match
-		= Telemetry::GetPlayerMatchInteger(Score, FlagRush_Common::C_Telemerty_Key_FlagScoreAssists);
+		= Telemetry::GetPlayerMatchInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagScoreAssists);
 	Net_FlagRush_FlagsAssists_Map
-		= Telemetry::GetPlayerMapInteger(Score, FlagRush_Common::C_Telemerty_Key_FlagScoreAssists);
+		= Telemetry::GetPlayerMapInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagScoreAssists);
 	Net_FlagRush_FlagsAssists_Round
-		= Telemetry::GetPlayerRoundInteger(Score, FlagRush_Common::C_Telemerty_Key_FlagScoreAssists);
+		= Telemetry::GetPlayerRoundInteger(Score, FlagRush_Common::C_Telemetry_Key_FlagScoreAssists);
 }
 
 /**

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -842,8 +842,8 @@ Void ScoreFlag(CSmPlayer Player) {
 
 	// Add the points
 	// Scoring player
-	Scores::AddClanRoundPoints(Player.CurrentClan, 1);
 	Scores::AddPlayerRoundPoints(Player.Score, FlagRush_Common::C_PointsValue_ScoreFlag);
+	Telemetry::AddPlayerRoundInteger(Player.Score, FlagRush_Common::C_Telemetry_Key_FlagsScored, 1);
 	FlagRush_UI::UpdateScore(Player.Score);
 	// Assisting player
 	declare FlagState::K_FlagPass LastPass = FlagState::Get().LastFlagPass;
@@ -852,14 +852,14 @@ Void ScoreFlag(CSmPlayer Player) {
 		declare CSmScore AssistingPlayerScore <=> GetScore(LastPass.OldCarrier.Login);
 		if (AssistingPlayerScore.TeamNum == Player.Score.TeamNum) {
 			Scores::AddPlayerRoundPoints(AssistingPlayerScore, FlagRush_Common::C_PointsValue_ScoreFlagAssist);
-			Telemetry::AddPlayerRoundInteger(AssistingPlayerScore, FlagRush_Common::C_Telemerty_Key_FlagScoreAssists, 1);
+			Telemetry::AddPlayerRoundInteger(AssistingPlayerScore, FlagRush_Common::C_Telemetry_Key_FlagScoreAssists, 1);
 			FlagRush_UI::UpdateScore(AssistingPlayerScore);
 			AssistingUser <=> LastPass.OldCarrier;
 		}
 	}
 
 	// Team
-	Telemetry::AddPlayerRoundInteger(Player.Score, FlagRush_Common::C_Telemetry_Key_FlagsScored, 1);
+	Scores::AddClanRoundPoints(Player.CurrentClan, 1);
 	FlagRush_UI::UpdateTeamScores();
 	ResetHandicaps(Player);
 	ResetFlag(True);


### PR DESCRIPTION
Issue: When a player scores a flag, the counter for the flags scored in the current round (small `+`-number) was not updated until anything else in the players score changed again.
Probably due to a small mistake during refactoring where I moved the wrong lines to the wrong spots. (Player score update in section commented with `// Team` and also the other way around)

Also fixed a typo in the name of the Telemetry key constant.