### PR TITLE
Replace legacy Layers lib with current lib

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
@@ -21,7 +21,7 @@
 #Include "TextLib" as TL
 
 #Include "Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp_UI.Script.txt" as WarmUpReadyUp_UI
-#Include "Libs/Nadeo/ModeLibs/Legacy/Layers2.Script.txt" as Layers
+#Include "Libs/Nadeo/Layers2.Script.txt" as Layers
 
 #Const C_Event_Type_PlayerReadyChanged	"PlayerReadyChanged"
 #Const C_Event_Type_TimeoutStart				"TimeoutStart"

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_UI.Script.txt
@@ -1,6 +1,6 @@
 #Include "TextLib" as TL
 
-#Include "Libs/Nadeo/ModeLibs/Legacy/Layers2.Script.txt"							as Layers
+#Include "Libs/Nadeo/Layers2.Script.txt"															as Layers
 #Include "Libs/Nadeo/TMxSM/Race/Scores.Script.txt"										as Scores
 
 #Include "Libs/Zrx/ModeLibs/Common/GameplayPhase.Script.txt"					as GameplayPhase


### PR DESCRIPTION
Replaced the Layers lib from the Legacy folder with the current version... which is practically the same, except for 2 new methods (GetScriptName & GetScriptVersion) and formatting.
Necessary? Probably not. But just keep it updated, I guess.