### PR TITLE
Team color cleanup

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/BaseModes/FlagRushProgressionBase.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/BaseModes/FlagRushProgressionBase.Script.txt
@@ -72,9 +72,9 @@
 
 // Teams
 #Setting S_Team1Name 												"" 			as "Force Team 1 Name"
-#Setting S_Team1Hue 												-1 			as "Force Team 1 Hue"
+#Setting S_Team1Hue 												-1 			as "Force Team 1 Hue. Range: [0, 360] or -1 for default"
 #Setting S_Team2Name 												"" 			as "Force Team 2 Name"
-#Setting S_Team2Hue 												-1 			as "Force Team 2 Hue"
+#Setting S_Team2Hue 												-1 			as "Force Team 2 Hue. Range: [0, 360] or -1 for default"
 #Setting S_UseClubTags											True		as "Use club tags for team names"
 #Setting S_UseTeamSkins											True		as "Use colored skins for teams"
 
@@ -191,10 +191,8 @@ FlagRush_XmlRpc::Load();
 
 FlagRush_Teams::SetTeam1NameOverride(S_Team1Name);
 FlagRush_Teams::SetTeam1HueOverride(S_Team1Hue);
-// FlagRush_Teams::SetTeam1ColorHexOverride(S_Team1Color);
 FlagRush_Teams::SetTeam2NameOverride(S_Team2Name);
 FlagRush_Teams::SetTeam2HueOverride(S_Team2Hue);
-//FlagRush_Teams::SetTeam2ColorHexOverride(S_Team2Color);
 FlagRush_Teams::UseClubTags(S_UseClubTags);
 
 declare Text[] ModeCommandsAdminLogins = TL::Split(",", S_ModeCommands_AdminLoginsCsv);

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Teams.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Teams.Script.txt
@@ -4,37 +4,27 @@
 #Include "TextLib" as TL
 
 #Const	C_DefaultTeamHue						120
-#Const	C_DefaultTeamHues						[0 => 240,1 => 0]
+#Const	C_DefaultTeamHues						[0 => 240, 1 => 0]
 
-#Const C_SkinNames [
-	"Skins/Models/CarSport/Stadium_Clan_ladybug.zip",
-	"Skins/Models/CarSport/Stadium_Clan_fox.zip",
-	"Skins/Models/CarSport/Stadium_Clan_bee.zip",
-	"Skins/Models/CarSport/Stadium_Clan_grasshopper.zip",
-	"Skins/Models/CarSport/Stadium_Clan_crocodile.zip",
-	"Skins/Models/CarSport/Stadium_Clan_peafowl.zip",
-	"Skins/Models/CarSport/Stadium_Clan_rabbit.zip",
-	"Skins/Models/CarSport/Stadium_Clan_polar_bear.zip",
-	"Skins/Models/CarSport/Stadium_Clan_dolphin.zip",
-	"Skins/Models/CarSport/Stadium_Clan_butterfly.zip",
-	"Skins/Models/CarSport/Stadium_Clan_octopus.zip",
-	"Skins/Models/CarSport/Stadium_Clan_pig.zip",
-	"Skins/Models/CarSport/Stadium_Clan_ladybug.zip"
-]
-#Const C_HueSkinLut [
-	"Red",
-	"Orange",
-	"Yellow",
-	"Lime",
-	"Green",
-	"Teal",
-	"Cyan",
-	"Azure",
-	"Blue",
-	"Purple",
-	"Magenta",
-	"Rose",
-	"Red"
+#Struct K_TeamColor {
+	Text TeamName;
+	Text SkinName;
+}
+
+#Const C_TeamColorLut [
+	K_TeamColor{ TeamName = "Red", SkinName = "Skins/Models/CarSport/Stadium_Clan_ladybug.zip" },
+	K_TeamColor{ TeamName = "Orange", SkinName = "Skins/Models/CarSport/Stadium_Clan_fox.zip" },
+	K_TeamColor{ TeamName = "Yellow", SkinName = "Skins/Models/CarSport/Stadium_Clan_bee.zip" },
+	K_TeamColor{ TeamName = "Lime", SkinName = "Skins/Models/CarSport/Stadium_Clan_grasshopper.zip" },
+	K_TeamColor{ TeamName = "Green", SkinName = "Skins/Models/CarSport/Stadium_Clan_crocodile.zip" },
+	K_TeamColor{ TeamName = "Teal", SkinName = "Skins/Models/CarSport/Stadium_Clan_peafowl.zip" },
+	K_TeamColor{ TeamName = "Cyan", SkinName = "Skins/Models/CarSport/Stadium_Clan_rabbit.zip" },
+	K_TeamColor{ TeamName = "Azure", SkinName = "Skins/Models/CarSport/Stadium_Clan_polar_bear.zip" },
+	K_TeamColor{ TeamName = "Blue", SkinName = "Skins/Models/CarSport/Stadium_Clan_dolphin.zip" },
+	K_TeamColor{ TeamName = "Purple", SkinName = "Skins/Models/CarSport/Stadium_Clan_butterfly.zip" },
+	K_TeamColor{ TeamName = "Magenta", SkinName = "Skins/Models/CarSport/Stadium_Clan_octopus.zip" },
+	K_TeamColor{ TeamName = "Rose", SkinName = "Skins/Models/CarSport/Stadium_Clan_pig.zip" },
+	K_TeamColor{ TeamName = "Red", SkinName = "Skins/Models/CarSport/Stadium_Clan_ladybug.zip" }
 ]
 
 #Struct K_TeamConfig {
@@ -51,33 +41,33 @@ declare Integer[Integer] G_TeamHueOverrides;
 declare Ident[Integer] G_SkinIds;
 declare Boolean G_UseClubTags;
 
-Integer GetClosestLutId(Integer Hue){
-	declare Integer id = 0;
-	declare Integer dist = 400;
-	for(i, 0, 12){
-		declare Integer h = i*30;
-		if(ML::Abs(Hue-h) < dist){
-			dist = ML::Abs(Hue-h);
-			id = i;
+Integer Private_GetClosestLutIndex(Integer Hue) {
+	declare Integer LutIdx = 0;
+	declare Integer Dist = 400;
+	for (I, 0, 12) {
+		declare Integer H = I * 30;
+		if (ML::Abs(Hue - H) < Dist){
+			Dist = ML::Abs(Hue - H);
+			LutIdx = I;
 		}
 	}
-	return id;
+	return LutIdx;
 }
 
 Void SetTeam1NameOverride(Text Name) {
-	G_TeamNameOverrides[0] = Name;
-}
-
-Void SetTeam2NameOverride(Text Name) {
 	G_TeamNameOverrides[1] = Name;
 }
 
+Void SetTeam2NameOverride(Text Name) {
+	G_TeamNameOverrides[2] = Name;
+}
+
 Void SetTeam1HueOverride(Integer Hue) {
-	G_TeamHueOverrides[0] = Hue;
+	G_TeamHueOverrides[1] = Hue;
 }
 
 Void SetTeam2HueOverride(Integer Hue) {
-	G_TeamHueOverrides[1] = Hue;
+	G_TeamHueOverrides[2] = Hue;
 }
 
 Void UseClubTags(Boolean UseClubTags) {
@@ -85,117 +75,116 @@ Void UseClubTags(Boolean UseClubTags) {
 }
 
 Void LoadSkins() {
-	for(i, 0, C_SkinNames.count-1){
-		G_SkinIds[i] = ItemList_AddWithSkin("CarSport", C_SkinNames[i]);
+	foreach (Index => TeamColor in C_TeamColorLut) {
+		G_SkinIds[Index] = ItemList_AddWithSkin("CarSport", TeamColor.SkinName);
 	}
 }
 
-Ident GetSkinModelIdForTeam(Integer Team) {
-	if (G_TeamConfigs.existskey(Team)) {
-		return G_TeamConfigs[Team].ItemId;
+Ident GetSkinModelIdForTeam(Integer Clan) {
+	if (G_TeamConfigs.existskey(Clan)) {
+		return G_TeamConfigs[Clan].ItemId;
 	}
 	return NullId;
 }
 
-Text GetSkinNameForTeam(Integer Team) {
-	if (G_TeamConfigs.existskey(Team)) {
-		return G_TeamConfigs[Team].SkinName;
+Text GetSkinNameForTeam(Integer Clan) {
+	if (G_TeamConfigs.existskey(Clan)) {
+		return G_TeamConfigs[Clan].SkinName;
 	}
 	return "";
 }
 
 Integer GetDefaultTeamHue(Integer Clan) {
-	return C_DefaultTeamHues.get(Clan-1, C_DefaultTeamHue);
+	return C_DefaultTeamHues.get(Clan - 1, C_DefaultTeamHue);
 }
 
 Text GetDefaultTeamName(Integer Clan) {
-	declare Integer Idx = GetClosestLutId(G_TeamConfigs[Clan-1].Hue);
-	return "Team "^C_HueSkinLut[Idx];
+	declare Text Teamname = "???";
+	if (G_TeamConfigs.existskey(Clan)) {
+		declare Integer Idx = Private_GetClosestLutIndex(G_TeamConfigs[Clan].Hue);
+		Teamname = C_TeamColorLut[Idx].TeamName;
+	}
+	return "Team " ^ Teamname;
 }
 
-Void Private_OverrideEmptyFields() {
-	for(TeamIndex, 0, 1) {
+Void Private_OverrideForcedOrEmptyFields() {
+	for(Clan, 1, 2) {
+		if(G_TeamHueOverrides.get(Clan, -1) != -1) // Forced
+			G_TeamConfigs[Clan].Hue = G_TeamHueOverrides[Clan];
+		else if (G_TeamConfigs[Clan].Hue == 0) // Was empty
+			G_TeamConfigs[Clan].Hue = GetDefaultTeamHue(Clan);
 
-		if(G_TeamHueOverrides.get(TeamIndex, -1) != -1)
-			G_TeamConfigs[TeamIndex].Hue = G_TeamHueOverrides[TeamIndex];
-		else if (G_TeamConfigs[TeamIndex].Hue == 0)
-			G_TeamConfigs[TeamIndex].Hue = GetDefaultTeamHue(TeamIndex + 1);
-
-		if (G_TeamNameOverrides.get(TeamIndex, "") != "")	// Forced
-			G_TeamConfigs[TeamIndex].Name = G_TeamNameOverrides[TeamIndex];
-		else if (G_TeamConfigs[TeamIndex].Name == "")					// Was empty
-			G_TeamConfigs[TeamIndex].Name = GetDefaultTeamName(TeamIndex + 1);
+		if (G_TeamNameOverrides.get(Clan, "") != "") // Forced
+			G_TeamConfigs[Clan].Name = G_TeamNameOverrides[Clan];
+		else if (G_TeamConfigs[Clan].Name == "") // Was empty
+			G_TeamConfigs[Clan].Name = GetDefaultTeamName(Clan);
 	}
 }
 
 Void Private_SetTeamNamesFromClubTags(){
-	if (G_UseClubTags) {
-		for (TeamIndex, 0, 1) {
-			declare Boolean ClubTagMissmatch;
-			declare Text[] ClubTagsTeam;
-			foreach (Player in Players) {
-				if (Player.CurrentClan == TeamIndex+1 && !Player.RequestsSpectate) { // Is playing
-					if (ClubTagsTeam.count == 0) {
-						ClubTagsTeam.add(Player.User.ClubTag);
-					} else if (!ClubTagsTeam.exists(Player.User.ClubTag)) {
-						ClubTagMissmatch = True;
-						break;
-					}
+	for (Clan, 1, 2) {
+		declare Boolean ClubTagMissmatch;
+		declare Text[] ClubTagsTeam;
+		foreach (Player in Players) {
+			if (Player.CurrentClan == Clan && !Player.RequestsSpectate) { // Is playing
+				if (ClubTagsTeam.count == 0) {
+					ClubTagsTeam.add(Player.User.ClubTag);
+				} else if (!ClubTagsTeam.exists(Player.User.ClubTag)) {
+					ClubTagMissmatch = True;
+					break;
 				}
 			}
+		}
 
-			if(!ClubTagMissmatch && ClubTagsTeam.count == 1) {
-				G_TeamConfigs[TeamIndex].ClubTag = ClubTagsTeam[0];
-				G_TeamConfigs[TeamIndex].Name = TL::StripFormatting(ClubTagsTeam[0]);
-			}
+		if (!ClubTagMissmatch && ClubTagsTeam.count == 1) {
+			G_TeamConfigs[Clan].ClubTag = ClubTagsTeam[0];
+			G_TeamConfigs[Clan].Name = TL::StripFormatting(ClubTagsTeam[0]);
 		}
 	}
 }
 
 Void Private_SetTeamHueFromMapType() {
-	if(Map != Null){
-		declare metadata Real[Integer] FlagRush_Meta_TeamHues for Map;
-		for (TeamIndex, 0, 1) {
-			declare Real TeamHue = FlagRush_Meta_TeamHues.get(TeamIndex+1,-1.);
-			if(TeamHue > 0){
-				TeamHue*=360;
-			}
-			G_TeamConfigs[TeamIndex].Hue = ML::NearestInteger(TeamHue);
+	declare metadata Real[Integer] FlagRush_Meta_TeamHues for Map;
+	for (Clan, 1, 2) {
+		declare Real TeamHue = FlagRush_Meta_TeamHues.get(Clan, -1.);
+		if(TeamHue > 0){
+			TeamHue *= 360;
 		}
+		G_TeamConfigs[Clan].Hue = ML::NearestInteger(TeamHue);
 	}
 }
 
 Void Private_ApplyToTeams() {
+	for (Clan, 1, 2) {
+		Teams[Clan - 1].Name = G_TeamConfigs[Clan].Name;
 
-	for (TeamIndex, 0, 1) {
-		Teams[TeamIndex].Name = G_TeamConfigs[TeamIndex].Name;
-
-		declare Integer Hue = G_TeamConfigs[TeamIndex].Hue;
+		declare Integer Hue = G_TeamConfigs[Clan].Hue;
 
 		declare Vec3 LightColor = NCL::GetLightColor(Hue*1.);
 		declare Vec3 MidColor = NCL::GetMidColor(Hue*1.);
 		declare Vec3 DarkColor = NCL::GetDarkColor(Hue*1.);
 
-		Teams[TeamIndex].ColorPrimary = MidColor;
-		Teams[TeamIndex].ColorSecondary = MidColor;
+		Teams[Clan - 1].ColorPrimary = MidColor;
+		Teams[Clan - 1].ColorSecondary = MidColor;
 
-		declare netwrite Vec3 Net_FlagRush_LightColor for Teams[TeamIndex];
+		declare netwrite Vec3 Net_FlagRush_LightColor for Teams[Clan - 1];
 		Net_FlagRush_LightColor = LightColor;
-		declare netwrite Vec3 Net_FlagRush_MidColor for Teams[TeamIndex];
+		declare netwrite Vec3 Net_FlagRush_MidColor for Teams[Clan - 1];
 		Net_FlagRush_MidColor = MidColor;
-		declare netwrite Vec3 Net_FlagRush_DarkColor for Teams[TeamIndex];
+		declare netwrite Vec3 Net_FlagRush_DarkColor for Teams[Clan - 1];
 		Net_FlagRush_DarkColor = DarkColor;
 
-		declare Integer id = GetClosestLutId(Hue);
-		G_TeamConfigs[TeamIndex].SkinName = C_SkinNames[id];
-		G_TeamConfigs[TeamIndex].ItemId = G_SkinIds.get(id,NullId);
+		declare Integer LutIdx = Private_GetClosestLutIndex(Hue);
+		G_TeamConfigs[Clan].SkinName = C_TeamColorLut[LutIdx].SkinName;
+		G_TeamConfigs[Clan].ItemId = G_SkinIds.get(LutIdx, NullId);
+		log("""Clan {{{Clan}}}, Config: {{{G_TeamConfigs[Clan]}}}""");
 	}
 }
 
 Void Init() {
-	G_TeamConfigs = [0 => K_TeamConfig{}, 1 => K_TeamConfig{}];
-	Private_SetTeamHueFromMapType();
-	Private_SetTeamNamesFromClubTags();
-	Private_OverrideEmptyFields();
+	G_TeamConfigs = [1 => K_TeamConfig{}, 2 => K_TeamConfig{}];
+	if (Map != Null) Private_SetTeamHueFromMapType();
+	if (G_UseClubTags) Private_SetTeamNamesFromClubTags();
+	Private_OverrideForcedOrEmptyFields();
 	Private_ApplyToTeams();
 }

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_ColorPalette.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_ColorPalette.Script.txt
@@ -1,11 +1,7 @@
 // FlagRush team colors
-#Const C_RedBase <0.8, 0., 0.133>
-#Const C_RedLight <1., 0.376, 0.098>
-#Const C_RedDark <0.4, 0., 0.133>
-
-#Const C_BlueBase <0.09, 0.09, 0.898>
-#Const C_BlueLight <0.094, 0.698, 0.902>
-#Const C_BlueDark <0.102, 0.039, 0.4>
+#Const C_TeamRed <0.8, 0., 0.133>
+#Const C_TeamBlue <0.09, 0.09, 0.898>
+#Const C_TeamNeutral <1., 1., 1.>
 
 // Status colors
 #Const C_Error <1., 0., 0.>
@@ -17,7 +13,6 @@
 
 // Other colors
 #Const C_NeutralDark <0., 0., 0.>
-#Const C_NeutralMid <1., 1., 1.>
 #Const C_NeutralLight <1., 1., 1.>
 
 // Opacities

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_Messages.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_Messages.Script.txt
@@ -25,8 +25,8 @@ Void Private_ClearAllMessages() {
 }
 
 Vec3 Private_GetTeamColor(Integer Clan) {
-	declare netwrite Vec3 Net_FlagRush_MidColor for Teams[Clan-1];
-	return Net_FlagRush_MidColor; //FlagRush_Teams::GetConfig(Clan).Color;
+	declare netwrite Vec3 Net_FlagRush_MidColor for Teams[Clan - 1];
+	return Net_FlagRush_MidColor;
 }
 
 Text Private_GetTeamColorCode(Integer Clan) {

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UIShared.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UIShared.Script.txt
@@ -19,13 +19,13 @@ Text GetTeamColorNetreadFunctions() {
 		}
 
 		Vec3 GetTeamMidColor(CTeam Team) {
-			if (Team == Null) return {{{ Colors::C_NeutralMid }}};
+			if (Team == Null) return {{{ Colors::C_TeamNeutral }}};
 			declare netread Vec3 Net_FlagRush_MidColor for Team;
 			return Net_FlagRush_MidColor;
 		}
 
 		Vec3 GetTeamMidColor(Integer Clan) {
-			if (Clan <= 0 || Clan > Teams.count) return {{{ Colors::C_NeutralMid }}};
+			if (Clan <= 0 || Clan > Teams.count) return {{{ Colors::C_TeamNeutral }}};
 			return GetTeamMidColor(Teams[Clan-1]);
 		}
 

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Header.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Header.Script.txt
@@ -19,7 +19,7 @@ Text GetManialink() {
 			</frame>
 			<label pos="-32.5 -0.5" z-index="1" size="35 8" text="Team Blue" textcolor="{{{ CL::RgbToHex6(FlagRush_Colors::C_NeutralLight) }}}" halign="center" textsize="4" id="name" textfont="GameFontRegular" valign="center2"/>
 
-			<quad pos="-60 " z-index="1" size="10 8" valign="center" id="background-score" style="UICommon64_1" substyle="BgFrame1" colorize="{{{ CL::RgbToHex6(FlagRush_Colors::C_BlueBase) }}}" halign="center"/>
+			<quad pos="-60 " z-index="1" size="10 8" valign="center" id="background-score" style="UICommon64_1" substyle="BgFrame1" colorize="{{{ CL::RgbToHex6(FlagRush_Colors::C_TeamBlue) }}}" halign="center"/>
 			<label pos="-60 -0.5" z-index="2" size="11.8 9" text="0" halign="center" valign="center2" textsize="5" textcolor="{{{ CL::RgbToHex6(FlagRush_Colors::C_NeutralLight) }}}" id="score" textfont="GameFontBlack" />
 		</frame>
 
@@ -29,7 +29,7 @@ Text GetManialink() {
 			</frame>
 			<label pos="32.5 -0.5" z-index="1" size="35 8" text="Team Red" textcolor="{{{ CL::RgbToHex6(FlagRush_Colors::C_NeutralLight) }}}" halign="center" textsize="4" id="name" textfont="GameFontRegular" valign="center2"/>
 
-			<quad pos="60 " z-index="1" size="10 8" valign="center" id="background-score" style="UICommon64_1" substyle="BgFrame1" colorize="{{{ CL::RgbToHex6(FlagRush_Colors::C_RedBase) }}}" halign="center"/>
+			<quad pos="60 " z-index="1" size="10 8" valign="center" id="background-score" style="UICommon64_1" substyle="BgFrame1" colorize="{{{ CL::RgbToHex6(FlagRush_Colors::C_TeamRed) }}}" halign="center"/>
 			<label pos="60 -0.5" z-index="2" size="11.8 9" text="0" halign="center" valign="center2" textsize="5" textcolor="{{{ CL::RgbToHex6(FlagRush_Colors::C_NeutralLight) }}}" id="score" textfont="GameFontBlack" />
 		</frame>
 
@@ -129,100 +129,97 @@ Text GetManialink() {
 	 * Set the default values for all controls.
 	 */
 	Void InitMlControls() {
-		TeamAreas[0].BackgroundGradient.Base.BgColor = GetTeamMidColor(1);// {{{ FlagRush_Colors::C_BlueBase }}};
-		TeamAreas[0].BackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(1); //{{{ FlagRush_Colors::C_BlueDark }}};
-		TeamAreas[0].BackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(1); //{{{ FlagRush_Colors::C_BlueLight }}};
-		TeamAreas[0].ScoreBackground.ModulateColor = GetTeamMidColor(1); //{{{ FlagRush_Colors::C_BlueBase }}};
+		TeamAreas[0].BackgroundGradient.Base.BgColor = GetTeamMidColor(1);
+		TeamAreas[0].BackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(1);
+		TeamAreas[0].BackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(1);
+		TeamAreas[0].ScoreBackground.ModulateColor = GetTeamMidColor(1);
 
-		TeamAreas[1].BackgroundGradient.Base.BgColor = GetTeamMidColor(2);//{{{ FlagRush_Colors::C_RedBase }}};
-		TeamAreas[1].BackgroundGradient.LeftGradient.ModulateColor = GetTeamLightColor(2);//{{{ FlagRush_Colors::C_RedLight }}};
-		TeamAreas[1].BackgroundGradient.RightGradient.ModulateColor = GetTeamDarkColor(2);//{{{ FlagRush_Colors::C_RedDark }}};
-		TeamAreas[1].ScoreBackground.ModulateColor = GetTeamMidColor(2);//{{{ FlagRush_Colors::C_RedBase }}};
+		TeamAreas[1].BackgroundGradient.Base.BgColor = GetTeamMidColor(2);
+		TeamAreas[1].BackgroundGradient.LeftGradient.ModulateColor = GetTeamLightColor(2);
+		TeamAreas[1].BackgroundGradient.RightGradient.ModulateColor = GetTeamDarkColor(2);
+		TeamAreas[1].ScoreBackground.ModulateColor = GetTeamMidColor(2);
 	}
 
 	/**
 	 * Updates the round scores (flags scored) for the teams.
 	 */
-	***UpdateTeams***
-	***
-	for (Team, 0, 1) {
-		declare netread Integer Net_FlagRush_TeamRoundScore for Teams[Team];
-		TeamAreas[Team].Score.Value = TL::ToText(Net_FlagRush_TeamRoundScore);
-		TeamAreas[Team].TeamName.Value = Teams[Team].Name;
+	Void UpdateTeams() {
+		for (Team, 0, 1) {
+			declare netread Integer Net_FlagRush_TeamRoundScore for Teams[Team];
+			TeamAreas[Team].Score.Value = TL::ToText(Net_FlagRush_TeamRoundScore);
+			TeamAreas[Team].TeamName.Value = Teams[Team].Name;
+		}
+		InitMlControls();
 	}
-	InitMlControls();
-	***
 
 	/**
 	 * Updates the center timer.
 	 */
-	***UpdateTimer***
-	***
-	declare Integer RoundTimeLeft = Net_EndTime - GameTime;
-	declare Boolean IsTimeLeft = RoundTimeLeft > 0;
-	Timer.TimerLabel.TextSizeReal = 2.;
-	Timer.TimerLabel.AutoNewLine = False;
-	if(IsTimeLeft) {
-		Timer.Icon.Hide();
-		Timer.TimerLabel.Show();
-		Timer.TimerLabel.Value = TL::TimeToText(
-			ML::Max(RoundTimeLeft, 0),
-			RoundTimeLeft < 10000 && !FlagRush_Net_WarmUpIsRunning
-		);
+	Void UpdateTimer() {
+		declare netread Integer Net_EndTime for Teams[0];
+		declare netread Boolean FlagRush_Net_WarmUpIsRunning for Teams[0];
+		declare netread Boolean FlagRush_Net_OvertimeIsRunning for Teams[0];
 
-		if (FlagRush_Net_WarmUpIsRunning) {
+		declare Integer RoundTimeLeft = Net_EndTime - GameTime;
+		declare Boolean IsTimeLeft = RoundTimeLeft > 0;
+		Timer.TimerLabel.TextSizeReal = 2.;
+		Timer.TimerLabel.AutoNewLine = False;
+		if(IsTimeLeft) {
+			Timer.Icon.Hide();
+			Timer.TimerLabel.Show();
+			Timer.TimerLabel.Value = TL::TimeToText(
+				ML::Max(RoundTimeLeft, 0),
+				RoundTimeLeft < 10000 && !FlagRush_Net_WarmUpIsRunning
+			);
+
+			if (FlagRush_Net_WarmUpIsRunning) {
+				Timer.TimerLabel.TextColor = {{{ FlagRush_Colors::C_Warning }}};
+			} else if (IsTimeLeft && RoundTimeLeft / 1000 < 30) {
+				Timer.TimerLabel.TextColor = {{{ FlagRush_Colors::C_Error }}};
+			} else {
+				Timer.TimerLabel.TextColor = {{{ FlagRush_Colors::C_NeutralLight }}};
+			}
+		} else if (FlagRush_Net_OvertimeIsRunning && !FlagRush_Net_WarmUpIsRunning && Net_EndTime >= 0) {
+			Timer.Icon.Hide();
+			Timer.TimerLabel.Show();
+			Timer.TimerLabel.TextSizeReal = 1.5;
+			Timer.TimerLabel.AutoNewLine = True; // Else multi line string won't be centered
+			Timer.TimerLabel.Value = "Overtime" ^ "\n" ^ "+" ^ TL::TimeToText(-RoundTimeLeft);
 			Timer.TimerLabel.TextColor = {{{ FlagRush_Colors::C_Warning }}};
-		} else if (IsTimeLeft && RoundTimeLeft / 1000 < 30) {
-			Timer.TimerLabel.TextColor = {{{ FlagRush_Colors::C_Error }}};
 		} else {
-			Timer.TimerLabel.TextColor = {{{ FlagRush_Colors::C_NeutralLight }}};
+			declare netread K_Net_FlagState FlagRush_Net_FlagState for Teams[0];
+			Timer.Icon.Colorize = GetTeamMidColor(FlagRush_Net_FlagState.Holder.Clan);
+			Timer.Icon.Show();
+			Timer.TimerLabel.Hide();
 		}
-	} else if (FlagRush_Net_OvertimeIsRunning && !FlagRush_Net_WarmUpIsRunning && Net_EndTime >= 0) {
-		Timer.Icon.Hide();
-		Timer.TimerLabel.Show();
-		Timer.TimerLabel.TextSizeReal = 1.5;
-		Timer.TimerLabel.AutoNewLine = True; // Else multi line string won't be centered
-		Timer.TimerLabel.Value = "Overtime" ^ "\n" ^ "+" ^ TL::TimeToText(-RoundTimeLeft);
-		Timer.TimerLabel.TextColor = {{{ FlagRush_Colors::C_Warning }}};
-	} else {
-		Timer.Icon.Show();
-		Timer.TimerLabel.Hide();
-		Timer.Icon.Colorize = GetTeamMidColor(FlagRush_Net_FlagState.Holder.Clan);
 	}
-	***
 
 	/**
 	 * Updates the flag carrier display.
 	 */
-	***UpdateCarrier***
-	***
-	if (FlagRush_Net_WarmUpIsRunning) {
-		Carrier.CarrierLabel.Value = "WarmUp";
-		Carrier.CarrierLabel.TextColor = {{{ FlagRush_Colors::C_Warning }}};
-	} else {
-		Carrier.CarrierLabel.Value = FlagRush_Net_FlagState.Holder.Name;
-		Carrier.CarrierLabel.TextColor = GetTeamMidColor(FlagRush_Net_FlagState.Holder.Clan);
+	Void UpdateCarrier() {
+		declare netread Boolean FlagRush_Net_WarmUpIsRunning for Teams[0];
+		if (FlagRush_Net_WarmUpIsRunning) {
+			Carrier.CarrierLabel.Value = "WarmUp";
+			Carrier.CarrierLabel.TextColor = {{{ FlagRush_Colors::C_Warning }}};
+		} else {
+			declare netread K_Net_FlagState FlagRush_Net_FlagState for Teams[0];
+			Carrier.CarrierLabel.Value = FlagRush_Net_FlagState.Holder.Name;
+			Carrier.CarrierLabel.TextColor = GetTeamMidColor(FlagRush_Net_FlagState.Holder.Clan);
+		}
 	}
-	***
-
-	Void DoNothing(){}
 
 	main() {
 
 		AssignMlControlReferences();
 		InitMlControls();
 
-		declare netread Integer Net_EndTime for Teams[0];
-		declare netread K_Net_FlagState FlagRush_Net_FlagState for Teams[0];
-		declare netread Boolean FlagRush_Net_WarmUpIsRunning for Teams[0];
-		declare netread Boolean FlagRush_Net_OvertimeIsRunning for Teams[0];
-
 		while (True) {
 			yield;
 
-			+++UpdateTeams+++
-			+++UpdateTimer+++
-			+++UpdateCarrier+++
+			UpdateTeams();
+			UpdateTimer();
+			UpdateCarrier();
 		}
 	}
 	--></script>

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Respawn.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Respawn.Script.txt
@@ -46,10 +46,7 @@ Text GetManialink() {
 			}
 
 			GaugeFrame.Size.X = ML::Clamp(80. * Ratio, 0., 80.);
-			declare Integer teamId = InputPlayer.CurrentClan-1;
-			if (Teams.existskey(teamId)) {
-				RespawnQuad.Colorize = GetTeamMidColor(Teams[teamId]) * 0.5;
-			}
+			RespawnQuad.Colorize = GetTeamDarkColor(InputPlayer.CurrentClan);
 			RespawnLabel.SetText("Respawning in " ^ (SecondsRemaining + 1) ^ "...");
 
 		}

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/ScoresTable.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/ScoresTable.Script.txt
@@ -198,36 +198,36 @@ Text GetManialink() {
 		// Team Blue
 		{
 			declare K_BackgroundGradient TeamNameBackgroundGradient = TeamScoreboards[0].TeamNameBackgroundGradient;
-			TeamNameBackgroundGradient.Base.BgColor = GetTeamMidColor(1);//{{{ FlagRush_Colors::C_BlueBase }}};
-			TeamNameBackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(1);//{{{ FlagRush_Colors::C_BlueDark }}};
-			TeamNameBackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(1);//{{{ FlagRush_Colors::C_BlueLight }}};
+			TeamNameBackgroundGradient.Base.BgColor = GetTeamMidColor(1);
+			TeamNameBackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(1);
+			TeamNameBackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(1);
 
 			for (CardIndex, 0, 4) {
 				declare K_PlayerCard Playercard = TeamScoreboards[0].Playercards[CardIndex];
-				Playercard.Avatar.BgColor = GetTeamMidColor(1);//{{{ FlagRush_Colors::C_BlueBase }}};
+				Playercard.Avatar.BgColor = GetTeamMidColor(1);
 				declare K_BackgroundGradient PlayercardBackgroundGradient = Playercard.BackgroundGradient;
 				PlayercardBackgroundGradient.Base.Opacity = 0.;
-				PlayercardBackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(1);//{{{ FlagRush_Colors::C_BlueDark }}};
+				PlayercardBackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(1);
 				PlayercardBackgroundGradient.LeftGradient.Opacity = {{{ FlagRush_Colors::C_TransparentBackgroundOpacity }}};
-				PlayercardBackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(1);//{{{ FlagRush_Colors::C_BlueLight }}};
+				PlayercardBackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(1);
 				PlayercardBackgroundGradient.RightGradient.Opacity = {{{ FlagRush_Colors::C_TransparentBackgroundOpacity }}};
 			}
 		}
 		// Team Red
 		{
 			declare K_BackgroundGradient TeamNameBackgroundGradient = TeamScoreboards[1].TeamNameBackgroundGradient;
-			TeamNameBackgroundGradient.Base.BgColor = GetTeamMidColor(2);//{{{ FlagRush_Colors::C_RedBase }}};
-			TeamNameBackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(2);//{{{ FlagRush_Colors::C_RedDark }}};
-			TeamNameBackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(2);//{{{ FlagRush_Colors::C_RedLight }}};
+			TeamNameBackgroundGradient.Base.BgColor = GetTeamMidColor(2);
+			TeamNameBackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(2);
+			TeamNameBackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(2);
 
 			for (CardIndex, 0, 4) {
 				declare K_PlayerCard Playercard = TeamScoreboards[1].Playercards[CardIndex];
-				Playercard.Avatar.BgColor = GetTeamMidColor(2);//{{{ FlagRush_Colors::C_RedBase }}};
+				Playercard.Avatar.BgColor = GetTeamMidColor(2);
 				declare K_BackgroundGradient PlayercardBackgroundGradient = Playercard.BackgroundGradient;
 				PlayercardBackgroundGradient.Base.Opacity = 0.;
-				PlayercardBackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(2);//{{{ FlagRush_Colors::C_RedDark }}};
+				PlayercardBackgroundGradient.LeftGradient.ModulateColor = GetTeamDarkColor(2);
 				PlayercardBackgroundGradient.LeftGradient.Opacity = {{{ FlagRush_Colors::C_TransparentBackgroundOpacity }}};
-				PlayercardBackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(2);//{{{ FlagRush_Colors::C_RedLight }}};
+				PlayercardBackgroundGradient.RightGradient.ModulateColor = GetTeamLightColor(2);
 				PlayercardBackgroundGradient.RightGradient.Opacity = {{{ FlagRush_Colors::C_TransparentBackgroundOpacity }}};
 			}
 		}

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -302,7 +302,7 @@ Void Player_Initialize(CSmPlayer Player) {
 	Player.UseCrudeExtrapolation = !UsePvPCollisions && S_UseCrudeExtrapolation;
 	Player.Dossard_Number = "  ";
 	Player.Dossard_Color = <1., 1., 1.>;
-	if (S_UseTeamSkins) Player.ForceModelId = FlagRush_Teams::GetSkinModelIdForTeam(Player.RequestedClan - 1);
+	if (S_UseTeamSkins) Player.ForceModelId = FlagRush_Teams::GetSkinModelIdForTeam(Player.RequestedClan);
 	else Player.ForceModelId = NullId;
 }
 


### PR DESCRIPTION
- Remove commented out code
- Minor structuring changes to FlagRush_Teams
  - Move Default color teamnames and skins to a constant array of structs
  - Use "Clan" instead of "Team" or "TeamIndex" for consistency
- Code style