### PR TITLE
Add setting and commands for admin approval to end warmup (default off)

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/BaseModes/FlagRushProgressionBase.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/BaseModes/FlagRushProgressionBase.Script.txt
@@ -69,6 +69,7 @@
 #Setting S_UseTurns													False 	as "<hidden>" // "Use turns (Reset after a player scores a flag)"
 #Setting S_UseOvertime											True 		as "Use overtime when round is tied"
 #Setting S_UseWarmUp												True		as "Use warm up"
+#Setting S_WarmUpWaitForApproval						False		as "<hidden>" // Wait for admin approval in warmup to continue (for competition situations)
 
 // Teams
 #Setting S_Team1Name 												"" 			as "Force Team 1 Name"
@@ -127,6 +128,9 @@
 
 // #Command	Command_BalanceTeams						(Boolean) as		"Balance Teams"
 #Const		C_Command_BalanceTeams													"BalanceTeams"
+
+#Command	Command_ApproveWarmUpEnd				(Boolean) as		"<hidden>"
+#Const		C_Command_ApproveWarmUpEnd											"ApproveWarmUpEnd"
 
 #Const		C_Command_SetBots																"SetBots"
 #Const		C_Command_SetTimeLeft														"SetTimeLeft"
@@ -494,7 +498,8 @@ Private_WarmUpIsRunning = True;
 declare netwrite Boolean FlagRush_Net_WarmUpIsRunning for Teams[0];
 FlagRush_Net_WarmUpIsRunning = Private_WarmUpIsRunning;
 FlagRush_Messages::WarmUpStart(C_Duration_WarmUpStart);
-WarmUpReadyUp::Start();
+WarmUpReadyUp::Start(S_WarmUpWaitForApproval);
+if (S_WarmUpWaitForApproval) FlagRush_Messages::WarmUpWaitForApproval();
 MB_Sleep(C_Duration_WarmUpStart);
 declare CUIConfig::EUISequence PreviousSequence = UIManager.UIAll.UISequence;
 UIManager.UIAll.UISequence = CUIConfig::EUISequence::Playing;
@@ -753,6 +758,15 @@ foreach (Command in PendingCommands) {
 			if (!MB_TurnIsRunning()) return;
 			ModeUtils::SetEndTime(Now + Command.ValueInteger * 1000);
 			CommandText = """Set time limit to {{{ Command.ValueInteger }}} seconds remaining.""";
+		}
+		case C_Command_ApproveWarmUpEnd: {
+			WarmUpReadyUp::SetWarmUpEndApproval(Command.ValueBoolean);
+			if (Command.ValueBoolean) {
+				FlagRush_Messages::WarmUpApproved();
+			} else {
+				FlagRush_Messages::WarmUpWaitForApproval();
+			}
+			CommandText = """Approvel given: {{{ Command.ValueBoolean }}}.""";
 		}
 		case C_Command_Announce: {
 			UIManager.UIAll.QueueMessage(3000, FlagRush_Messages::C_MessagePriority_Default, CUIConfig::EMessageDisplay::Big, Command.ValueText, CUIConfig::EUISound::Default, 1);

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/Common/WarmUpReadyUp/WarmUpReadyUp.Script.txt
@@ -57,6 +57,8 @@ declare Boolean G_WarmUpShouldStop;
 declare Boolean[Text] G_PlayersReady;
 
 declare K_TimeoutState G_TimeoutState;
+declare Boolean G_WaitForApproval;
+declare Boolean G_Approval;
 
 /**
  * Getter for if warmup should stop.
@@ -77,6 +79,10 @@ K_WarmUpReadyUpEvent[] GetPendingEvents() {
  */
 Boolean[Text] GetPlayersReadyStates() {
 	return G_PlayersReady;
+}
+
+Void SetWarmUpEndApproval(Boolean Approved) {
+	G_Approval = Approved;
 }
 
 /**
@@ -123,12 +129,8 @@ Void Private_AbortTimeout() {
  * 	then start it.
  * If the timeout was started when at least one player in each clan was ready but now all players are ready,
  * 	then reduce timer.
- * If the itmeout was started when all players where ready but now only one player in each team is ready,
+ * If the timeout was started when all players where ready but now only one player in each team is ready,
  * 	then extend the timer to the remaining time.
- * If the timeout was start but now not every clan has a player,
- * 	then abort the timeout.
- *
- * This was pain! Please fix this if someone know an easier solution!
  */
 Void Private_UpdateWarmUpEndTime(Boolean AllClansAtLeastOnePlayerReady, Boolean AllClansAllPlayersReady) {
 	if (AllClansAllPlayersReady) {
@@ -143,30 +145,48 @@ Void Private_UpdateWarmUpEndTime(Boolean AllClansAtLeastOnePlayerReady, Boolean 
 		} else if (G_TimeoutState.State == C_Timeout_State_AllPlayersReady) {
 			Private_UpdateTimeout(C_Timeout_State_OnePlayerReady, C_Timeout_AtLeastOnePlayerReady - (Now - G_TimeoutState.StartTime));
 		}
-	} else {
-		if (G_TimeoutState.State != C_Timeout_State_NotStarted) {
-			Private_AbortTimeout();
+	}
+}
+
+/**
+ * Determines the total amount of players and how many of them are ready.
+ * The key for the returned array is the Clan number
+ */
+K_ClanReadyState[Integer] Private_ComputeClanReadyStates() {
+	declare K_ClanReadyState[Integer] ClanReadyStates;
+	foreach (Player in Players) {
+		// Ignore players without clan in clan mode
+		declare Boolean HasNoClanInClanMode = (UseClans || UseMultiClans) && Player.CurrentClan == 0;
+		if (HasNoClanInClanMode) continue;
+
+		// Initalize array entry if not present
+		if (!ClanReadyStates.existskey(Player.CurrentClan)) {
+			ClanReadyStates[Player.CurrentClan] = K_ClanReadyState{};
+		}
+
+		ClanReadyStates[Player.CurrentClan].NbPlayers += 1;
+		if (G_PlayersReady.get(Player.User.Login, False)) {
+			ClanReadyStates[Player.CurrentClan].NbPlayersReady += 1;
 		}
 	}
+	return ClanReadyStates;
 }
 
 /**
  * Checks if the match can start: At least two clans and one ready player in each clan.
  */
 Boolean Private_MatchCanStart() {
-	// Check players and clans
-	declare K_ClanReadyState[Integer] ClanReadyStates;
-	foreach (Player in Players) {
-		if ((UseClans || UseMultiClans) && Player.CurrentClan == 0) continue;
-		declare K_ClanReadyState PlayerClanReadyState = ClanReadyStates.get(Player.CurrentClan, K_ClanReadyState{});
-		PlayerClanReadyState.NbPlayers += 1;
-		if(G_PlayersReady.get(Player.User.Login, False)) {
-			PlayerClanReadyState.NbPlayersReady += 1;
+	// Check if admin confirmation is needed and given
+	if (G_WaitForApproval && !G_Approval) {
+		if (G_TimeoutState.State != C_Timeout_State_NotStarted) {
+			Private_AbortTimeout();
 		}
-		ClanReadyStates[Player.CurrentClan] = PlayerClanReadyState;
+		return False;
 	}
 
-	// There have to be at least two clans
+	declare K_ClanReadyState[Integer] ClanReadyStates = Private_ComputeClanReadyStates();
+
+	// There have to be at least two clans with players if clan mode active
 	if ((UseClans || UseMultiClans) && ClanReadyStates.count < 2) {
 		if(G_TimeoutState.State != C_Timeout_State_NotStarted) {
 			Private_AbortTimeout();
@@ -179,7 +199,15 @@ Boolean Private_MatchCanStart() {
 	declare Boolean AllClansAllPlayersReady = True;
 	foreach (Clan => ReadyState in ClanReadyStates) {
 		AllClansAtLeastOnePlayerReady = AllClansAtLeastOnePlayerReady && (ReadyState.NbPlayersReady >= 1);
-		AllClansAllPlayersReady = AllClansAllPlayersReady && (ReadyState.NbPlayersReady == ReadyState.NbPlayers) && AllClansAtLeastOnePlayerReady;
+		AllClansAllPlayersReady = AllClansAllPlayersReady && (ReadyState.NbPlayersReady == ReadyState.NbPlayers);
+	}
+
+	// There needs to be at least one ready player in each clan
+	if (!AllClansAtLeastOnePlayerReady) {
+		if(G_TimeoutState.State != C_Timeout_State_NotStarted) {
+			Private_AbortTimeout();
+		}
+		return False;
 	}
 
 	// Update Warmup EndTime
@@ -204,18 +232,25 @@ Boolean Private_MatchCanStart() {
 
 /**
  * Starts the warmup.
+ * @param WaitForConfirmation: If true, waits for the mode to confirm that the warmup can end, no matter how many players are ready.
  */
-Void Start() {
+Void Start(Boolean WaitForApproval) {
 	G_WarmUpShouldStop = False;
 	PendingEvents = [];
 	G_PlayersReady = [];
 	G_TimeoutState = K_TimeoutState{};
+	G_Approval = False;
+	G_WaitForApproval = WaitForApproval;
 	Net_SendPlayerReadyStates();
 
 	Layers::Create(WarmUpReadyUp_UI::C_ManialinkName, WarmUpReadyUp_UI::GetManialink());
 	Layers::SetType(WarmUpReadyUp_UI::C_ManialinkName, CUILayer::EUILayerType::Normal);
 	Layers::Attach(WarmUpReadyUp_UI::C_ManialinkName);
 	UIManager.UIAll.SendChat("""$<$f90Warmup!$> Ready up by clicking the "Ready"-Button or pressing F7 / """);
+}
+
+Void Start() {
+	Start(False);
 }
 
 /**

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_Messages.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_Messages.Script.txt
@@ -46,86 +46,100 @@ Void Private_QueueBigMessage(Text Message, Integer Duration, Integer Priority, C
 	UIManager.UIAll.QueueMessage(Duration, Priority, CUIConfig::EMessageDisplay::Big, Message, Sound, 0);
 }
 
+Void Private_SendChat(Text Message) {
+	UIManager.UIAll.SendChat("""{{{ C_ChatPrefix }}} $<{{{ Message }}}$>""");
+}
+
 Void MatchWin(Integer WinnerClan, Integer Duration) {
-	declare Text Message= """{{{ Private_GetColoredTeamName(WinnerClan) }}} won the match""";
+	declare Text Message = """{{{ Private_GetColoredTeamName(WinnerClan) }}} won the match""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::EndMatch);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void MatchDraw(Integer Duration) {
-	declare Text Message= """Match draw""";
+	declare Text Message = """Match draw""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::EndMatch);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void MapWin(Integer WinnerClan, Integer Duration) {
-	declare Text Message= """{{{ Private_GetColoredTeamName(WinnerClan) }}} won the map""";
+	declare Text Message = """{{{ Private_GetColoredTeamName(WinnerClan) }}} won the map""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::EndRound);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void MapDraw(Integer Duration) {
-	declare Text Message= "Map draw";
+	declare Text Message = "Map draw";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::EndRound);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void MapSkip(Integer Duration) {
-	declare Text Message= "Map skipped";
+	declare Text Message = "Map skipped";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::EndRound);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void RoundStart(Integer NbRound, Integer Duration) {
-	declare Text Message= """Round {{{ NbRound }}} start""";
+	declare Text Message = """Round {{{ NbRound }}} start""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::Default);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void RoundWin(Integer WinnerClan, Integer Duration)  {
-	declare Text Message= """{{{ Private_GetColoredTeamName(WinnerClan) }}} won the round""";
+	declare Text Message = """{{{ Private_GetColoredTeamName(WinnerClan) }}} won the round""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::EndRound);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void RoundDraw(Integer Duration) {
-	declare Text Message= "Round draw";
+	declare Text Message = "Round draw";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::EndRound);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void RoundSkip(Integer Duration) {
-	declare Text Message= "Round skipped";
+	declare Text Message = "Round skipped";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::EndRound);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void OvertimeStart(Integer Duration) {
-	declare Text Message= """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}Overtime$>""";
+	declare Text Message = """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}Overtime$>""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::Default);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void WarmUpStart(Integer Duration) {
-	declare Text Message= """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}WarmUp$>""";
+	declare Text Message = """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}WarmUp$>""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::Default);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void WarmUpEnd(Integer Duration) {
-	declare Text Message= """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}WarmUp end$>""";
+	declare Text Message = """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}WarmUp end$>""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::Default);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
+Void WarmUpWaitForApproval() {
+	declare Text Message = """$<${{{CL::RgbToHex3(FlagRush_Colors::C_Warning)}}}Waiting for admin confirmation to start the match.$>""";
+	Private_SendChat(Message);
+}
+
+Void WarmUpApproved() {
+	declare Text Message = """$<${{{CL::RgbToHex3(FlagRush_Colors::C_Success)}}}The match can start.$>""";
+	Private_SendChat(Message);
+}
+
 Void PauseStart(Integer Duration) {
-	declare Text Message= """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}The round was paused$>""";
+	declare Text Message = """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}The round was paused$>""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::Default);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
 
 Void PauseEnd(Integer Duration) {
-	declare Text Message= """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}The round continues$>""";
+	declare Text Message = """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}The round continues$>""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Progression, CUIConfig::EUISound::Default);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 }
@@ -138,7 +152,7 @@ Void FlagPickUp(CSmPlayer Player, Integer Duration) {
 }
 
 Void FlagScored(CSmPlayer Scorer, Integer Duration) {
-	declare Text Message= """{{{ Private_GetColoredPlayerName(Scorer) }}} scored for {{{ Private_GetColoredTeamName(Scorer.CurrentClan) }}}""";
+	declare Text Message = """{{{ Private_GetColoredPlayerName(Scorer) }}} scored for {{{ Private_GetColoredTeamName(Scorer.CurrentClan) }}}""";
 	declare Vec3 TeamColor = Private_GetTeamColor(Scorer.CurrentClan);
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Event, CUIConfig::EUISound::Finish);
 	FlagRush_Sound::Play(["file://Media/Sounds/Nadeo/CommonLibs/Game/KnockOutPlayer_01.wav", "file://Media/Sounds/Nadeo/CommonLibs/Game/ShowWinners.wav"]);
@@ -148,13 +162,13 @@ Void FlagScored(CSmPlayer Scorer, Integer Duration) {
 Void FlagDropped(CUser OldCarrierUser, Integer Duration) {
 	declare CSmScore OldCarrierScore <=> ModeUtils::GetScore(OldCarrierUser.Login);
 	declare Text PlayerName = """$<{{{ Private_GetTeamColorCode(OldCarrierScore.TeamNum) }}}{{{ OldCarrierScore.User.Name }}}$>""";
-	declare Text Message= """{{{ PlayerName }}} dropped the flag$>""";
+	declare Text Message = """{{{ PlayerName }}} dropped the flag$>""";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Event, CUIConfig::EUISound::Checkpoint);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Flag);
 }
 
 Void FlagReset(Integer Duration) {
-	declare Text Message= "The flag was reset";
+	declare Text Message = "The flag was reset";
 	Private_QueueBigMessage(Message, Duration, C_MessagePriority_Event, CUIConfig::EUISound::Warning);
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Flag);
 }
@@ -165,7 +179,7 @@ Void FlagCarrierTeleport() {
 }
 
 Void PlayerOutOfBounds(CSmPlayer Player) {
-	declare Text Message= """{{{ Private_GetColoredPlayerName(Player) }}} went out of bounds""";
+	declare Text Message = """{{{ Private_GetColoredPlayerName(Player) }}} went out of bounds""";
 	EventFeed::SendMessage(Message, EventFeed::C_IconName_Info);
 	// Play a Sound for the dead player
 	declare CUIConfig UI = UIManager.GetUI(Player);
@@ -190,13 +204,16 @@ Void Welcome(CSmPlayer Player, Text Version) {
 }
 
 Void CriticalSettingUpdate_RestartTurn() {
-	UIManager.UIAll.SendChat("""{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}A critical setting was updated! Restarting the the current turn...$>""");
+	declare Text Message = """{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}A critical setting was updated! Restarting the the current turn...$>""";
+	Private_SendChat(Message);
 }
 
 Void InvalidMap() {
-	UIManager.UIAll.SendChat("""{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Error) }}}The map does not conform to the FlagRush map specification. Skipping...$>""");
+	declare Text Message = """{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Error) }}}The map does not conform to the FlagRush map specification. Skipping...$>""";
+	Private_SendChat(Message);
 }
 
 Void AllPlayersLeft_SkipMatch() {
-	UIManager.UIAll.SendChat("""{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}All players left, skipping match...$>""");
+	declare Text Message = """{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}All players left, skipping match...$>""";
+	Private_SendChat(Message);
 }


### PR DESCRIPTION
- Adds a setting (hidden) to determine if admin approval is needed to end warmup
- Timers in warmup will be aborted or not even started if no approval is given
- Mode command (through nadeo command interface and mode commands) to send approval