### PR TITLE
Make respawn delay dependent on team size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 	* The base you have to attack shows a crosshair icon in the color of the opposite team.
 	* The base you have to defend shows a shield icon in the color of your team.
 * Adjusted respawn timer UI to take spawn animation duration into account.
-* Adjusted default respawn delay to 4.0 seconds (from 3.0 seconds)
+* Adjusted respawn delay functionality. Respawn delay is now dependent on the amount of players in a team: `Respawn delay = Amount of player in the team * S_RespawnDelayPerPlayer (Setting)`
 * Adjusted default flag carrier acceleration coef to 0.66 (from 0.7)
 * Adjusted default flag carrier adherence coef to 0.9 (from 1.0)
 * Fix Z-Index of the UI that broke after the september Trackmania update.

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Respawn.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Respawn.Script.txt
@@ -31,24 +31,25 @@ Text GetManialink() {
 		declare Integer TotalRespawnTime = -1;
 		while (True) {
 			yield;
+
 			declare Integer MillisRemaining = Net_SpawnDate - GameTime + {{{ FlagRush_Common::C_SpawnAnimDuration }}};
 			if (Net_SpawnDate <= 0 || MillisRemaining <= 0 || IsSpectator) {
-				RespawnFrame.Visible = False;
+				RespawnFrame.Hide();
+				TotalRespawnTime = -1;
 				continue;
 			}
-
-			declare Integer SecondsRemaining = MillisRemaining / 1000;
-			declare Real Ratio = ML::NearestReal(MillisRemaining) / TotalRespawnTime;
-			RespawnFrame.Visible = True;
 
 			if (TotalRespawnTime <= 0) {
 				TotalRespawnTime = MillisRemaining;
 			}
+			declare Real Ratio = ML::NearestReal(MillisRemaining) / TotalRespawnTime;
 
+			// Display
+			declare Integer SecondsRemaining = MillisRemaining / 1000 + 1;
 			GaugeFrame.Size.X = ML::Clamp(80. * Ratio, 0., 80.);
 			RespawnQuad.Colorize = GetTeamDarkColor(InputPlayer.CurrentClan);
-			RespawnLabel.SetText("Respawning in " ^ (SecondsRemaining + 1) ^ "...");
-
+			RespawnLabel.SetText("Respawning in " ^ SecondsRemaining ^ "...");
+			RespawnFrame.Show();
 		}
 	}
 	--></script>

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -73,7 +73,7 @@
 #Setting S_FlagCarrierControl								1.0 		as "<hidden>" // Flag carrier steering control (0.0 - 1.0)
 #Setting S_FlagCarrierAdherence							0.9 		as "<hidden>" // Flag carrier adherence (0.0 - 1.0)
 #Setting S_RespawnSpeedLimitKmh							30.			as "<hidden>" // Speed limit for player to respawn
-#Setting S_RespawnDelay											4.0 		as "Respawn Delay (seconds) (+1.5s Spawn animation)"
+#Setting S_RespawnDelayPerPlayer						1.0 		as "Respawn delay (seconds) per player in a team"
 #Setting S_DropFlagPickupPenalty						3.			as "<hidden>" // Flag pickup cooldown after dropping (seconds)
 #Setting S_DropFlagOnTeleportDetection			True		as "<hidden>"
 #Setting S_UseCollisions										False		as "Use collisions (experimental)"
@@ -323,7 +323,8 @@ Void Player_Spawn(CSmPlayer Player) {
 Void Player_Unspawn(CSmPlayer Player) {
 	UnspawnPlayer(Player);
 	declare netwrite Integer Net_SpawnDate for Player;
-	Net_SpawnDate = Now + ML::NearestInteger(S_RespawnDelay * 1000);
+	declare Integer SpawnDelay = ML::NearestInteger(S_RespawnDelayPerPlayer * ClansNbPlayers[Player.RequestedClan] * 1000);
+	Net_SpawnDate = Now + SpawnDelay;
 }
 
 Void Player_ApplyHandicaps(CSmPlayer Player) {


### PR DESCRIPTION
The respawn delay was always the same value for both teams, regardless of team sizes. This made it unfair for unbalanced teams in casual play and annoying with low amounts of player.
Instead, th respawn delay should now be dependent on teamsizes. Therefore a team with less players is less punished by respawning than a team with many players, making it easier to defend for the team that already in in a disadvantage.
Respawn delay is determined as follow: `S_RespawnDelayPerPlayer * ClansNbPlayers[Player.RequestedClan] * 1000`