### PR TITLE
Fix double prefix on chat messages send by FlagRush_Messages Lib

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_Messages.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_Messages.Script.txt
@@ -204,16 +204,16 @@ Void Welcome(CSmPlayer Player, Text Version) {
 }
 
 Void CriticalSettingUpdate_RestartTurn() {
-	declare Text Message = """{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}A critical setting was updated! Restarting the the current turn...$>""";
+	declare Text Message = """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}A critical setting was updated! Restarting the the current turn...$>""";
 	Private_SendChat(Message);
 }
 
 Void InvalidMap() {
-	declare Text Message = """{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Error) }}}The map does not conform to the FlagRush map specification. Skipping...$>""";
+	declare Text Message = """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Error) }}}The map does not conform to the FlagRush map specification. Skipping...$>""";
 	Private_SendChat(Message);
 }
 
 Void AllPlayersLeft_SkipMatch() {
-	declare Text Message = """{{{ C_ChatPrefix }}} $<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}All players left, skipping match...$>""";
+	declare Text Message = """$<${{{ CL::RgbToHex3(FlagRush_Colors::C_Warning) }}}All players left, skipping match...$>""";
 	Private_SendChat(Message);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53338174/199331100-8c5ed140-7b0d-411c-9070-f494933ec09e.png)
