### PR TITLE
fix podium showing after map load

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/BaseModes/FlagRushProgressionBase.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/BaseModes/FlagRushProgressionBase.Script.txt
@@ -277,8 +277,8 @@ if (!MapValid) {
 FlagRush_XmlRpc::Send_MapStart();
 FlagRush_UI::StartMap();
 FlagRush_Teams::Init();
-MB_Synchro();
 UIManager.UIAll.UISequence = CUIConfig::EUISequence::PlayersPresentation;
+MB_Synchro();
 ***
 
 ***StartMap***


### PR DESCRIPTION
The podium is showing after map load, because the mode waits for player sync before changing the UI sequence, meaning that the Podium sequence is still active. Players that load before other will therefore see the podium for a short duration at the beginning of the new map.
Fixed by setting the UI sequence before performing the sync.