### PR TITLE
Fix wrong scores being shown on podium

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UI.Script.txt
@@ -143,7 +143,7 @@ Void Private_AttachModules() {
 	Layers::Attach(C_LayerName_Flash);
 
 	// Podium background
-	Layers::Create(C_LayerName_Podium, ""); // Empty Manialink; Content set when set active
+	Layers::Create(C_LayerName_Podium, FlagRush_Podium::GetManialink()); // Empty Manialink; Content set when set active
 	Layers::SetType(C_LayerName_Podium, CUILayer::EUILayerType::ScreenIn3d);
 	Layers::Get(C_LayerName_Podium).AttachId = C_AttachId_Podium;
 	// Don't attach yet; only explicitly during podium
@@ -155,7 +155,7 @@ Void Private_AttachModules() {
 }
 
 Void AttachPodiumBackground(CSmScore[] PodiumPlayerScores) {
-	Layers::Update(C_LayerName_Podium, FlagRush_Podium::GetManialink(PodiumPlayerScores));
+	FlagRush_Podium::SetContent(PodiumPlayerScores);
 	Layers::Attach(C_LayerName_Podium);
 	Layers::Hide(C_LayerName_Markers);
 }

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/PodiumBackground.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/PodiumBackground.Script.txt
@@ -17,8 +17,7 @@
 	Integer FlagsStolenPlacement;
 }
 
-Text GetManialink(CSmScore[] PodiumScores) {
-
+Void SetContent(CSmScore[] PodiumScores) {
 	declare CSmScore[] FlagsScoredMatchRanking = FlagRush_Scores::GetPlayerFlagsScoredMatchRanking();
 	declare CSmScore[] AssistsMatchRanking = FlagRush_Scores::GetPlayerAssistsMatchRanking();
 	declare CSmScore[] FlagsStolenMatchRanking = FlagRush_Scores::GetPlayerFlagsStealsMatchRanking();
@@ -45,7 +44,9 @@ Text GetManialink(CSmScore[] PodiumScores) {
 			FlagRush_Net_PodiumPlacementConfigs[Placement] = K_PodiumPlaceConfig{ Present = False };
 		}
 	}
+}
 
+Text GetManialink() {
 	return """
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <manialink version="3" name="FlagRush_PodiumBackground">
@@ -185,7 +186,7 @@ Text GetManialink(CSmScore[] PodiumScores) {
 		}
 	}
 
-	Void SetContent() {
+	Void UpdateContent() {
 		declare netread K_PodiumPlaceConfig[Integer] FlagRush_Net_PodiumPlacementConfigs for Teams[0];
 		foreach (Index => Player in G_Players) {
 			declare K_PodiumPlaceConfig Config = FlagRush_Net_PodiumPlacementConfigs.get(Index + 1, K_PodiumPlaceConfig{ Present = False });
@@ -216,7 +217,10 @@ Text GetManialink(CSmScore[] PodiumScores) {
 
 	main() {
 		InitMlControls();
-		SetContent();
+		while (True) {
+			yield;
+			UpdateContent();
+		}
 	}
 	--></script>
 </manialink>


### PR DESCRIPTION
Due to network latency and the content of the podium background only being set during Manialink initialization it was possible for the podium screen to show the wrong content if manialink reached the client before the netvars.