### PR TITLE
Flag relay nerf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
+# Changelog
+
 ## 1.4.0
+
+### General
+* Manually dropping the flag in a stack of players is now considered a pass/steal instead of a drop.
+- Flag steal resistance on passes between team members has been removed.
+	* Picking up a dropped flag or stealing it from your opponent still gives steal resistance.
+	* Steal resistance can still be achieved by dropping the flag in front of your teammates for them to pick it up.
+	* A setting has been added to turn this new behaviour on or off: `S_FlagStealResistanceOnTeamPass` (Boolean)
 
 ### UI
 + Added a toggle button on the scoreboard to toggle between displaying map or match scores.
 + Fixed podium screen after december Trackmania update.
+
+---
 
 ## 1.3.1
 
@@ -14,6 +25,8 @@
 + Added a message to the Event feed when a player respawns.
 * Fix wrong scores sometimes shown on podium screen.
 * Fix scoresboard to show map points in "Points" counter instead of match points.
+
+---
 
 ## 1.3.0
 
@@ -43,10 +56,14 @@
 * Adjusted default flag carrier adherence coef to 0.9 (from 1.0)
 * Adjusted respawn delay functionality: Respawn delay is now dependent on the amount of players in a team: `Respawn delay = Amount of player in the team * S_RespawnDelayPerPlayer (Setting) + 1.5 seconds Spawn animation`
 
+---
+
 ## 1.2.1
 + New mode commands (Callvotes, ModeCommandsUI) for setting match/map/round points and auto team balance.
 * Fix scorestable player statistics
 * Bug fixes and optimizations
+
+---
 
 ## 1.2.0
 + New Hitboxes! Completely new and very precise player hit detection.
@@ -65,11 +82,17 @@
 	* Fine extrapolation can still be reenabled by serveradmins using the setting `S_UseCrudeExtrapolation` (Set to `False`). It will also automatically be enabled when playing with collisions, as it's needed for collisions to work.
 * Some bug and crash fixes and general optimizations
 
+---
+
 ## 1.1.2
 * Fixed an issue with the respawn timer constantly resetting when falling into offzone
 
+---
+
 ## 1.1.1
 * Fixed an small issue with the radar not displaying some players correctly when in spectator
+
+---
 
 ## 1.1.0
 + Added a radar ("minimap") on screen, which shows the location of nearby players and the flag

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_FlagState.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_FlagState.Script.txt
@@ -31,9 +31,10 @@
 	Vec3 Position;
 	Vec3 PrevPosition;
 	Vec3 LastSafePosition;
-	K_FlagDrop LastDrop;
 	Integer CurrentStateStartDate;
 	Integer CurrentStateEndDate;
+	Boolean HasStealResistance;
+	K_FlagDrop LastDrop;
 	K_FlagPass LastFlagPass;
 }
 
@@ -48,6 +49,7 @@
 	Vec3 Position;
 	Integer CurrentStateStartDate;
 	Integer CurrentStateEndDate;
+	Boolean HasStealResistance;
 }
 
 #Const C_TeleportThreshold 					32 // One block
@@ -153,6 +155,7 @@ Boolean CarrierTeleported() {
 	FlagRush_Net_FlagState.Position = G_FlagState.Position;
 	FlagRush_Net_FlagState.CurrentStateStartDate = G_FlagState.CurrentStateStartDate;
 	FlagRush_Net_FlagState.CurrentStateEndDate = G_FlagState.CurrentStateEndDate;
+	FlagRush_Net_FlagState.HasStealResistance = G_FlagState.HasStealResistance;
 }
 
 /**
@@ -165,6 +168,7 @@ Void SetAtLandmark(CMapLandmark Landmark, Integer CurrentStateEndDate) {
 	G_FlagState.Carrier = K_Player{};
 	G_FlagState.CurrentStateStartDate = Now;
 	G_FlagState.CurrentStateEndDate = CurrentStateEndDate;
+	G_FlagState.HasStealResistance = False;
 	Private_Net_SendFlagState();
 	FlagRush_Markers::FlagMarker_SetOnLandmark(Landmark);
 }
@@ -178,18 +182,19 @@ Void SetAtLandmark(CMapLandmark Landmark) {
  * Sets the flag state to be at a player.
  * Also updates the position, the marker and unsets the landmark.
  */
-Void SetAtCarrier(CSmPlayer Carrier, Integer CurrentStateEndDate) {
+Void SetAtCarrier(CSmPlayer Carrier, Integer CurrentStateEndDate, Boolean HasStealResistance) {
 	G_FlagState.Carrier = Private_PlayerToStruct(Carrier);
 	G_FlagState.Landmark = Null;
 	G_FlagState.Position = Carrier.Position;
 	G_FlagState.CurrentStateStartDate = Now;
 	G_FlagState.CurrentStateEndDate = CurrentStateEndDate;
+	G_FlagState.HasStealResistance = HasStealResistance;
 	Private_Net_SendFlagState();
 	FlagRush_Markers::FlagMarker_SetOnPlayer(Carrier);
 }
 
-Void SetAtCarrier(CSmPlayer Carrier) {
-	SetAtCarrier(Carrier, -1);
+Void SetAtCarrier(CSmPlayer Carrier, Boolean HasStealResistance) {
+	SetAtCarrier(Carrier, -1, HasStealResistance);
 }
 
 /**
@@ -202,6 +207,7 @@ Void SetAtPosition(Vec3 Position, Integer CurrentStateEndDate) {
 	 G_FlagState.Landmark = Null;
 	 G_FlagState.CurrentStateStartDate = Now;
 	 G_FlagState.CurrentStateEndDate = CurrentStateEndDate;
+	 G_FlagState.HasStealResistance = False;
 	 Private_Net_SendFlagState();
 	 if (Position == C_Position_Invalid) {
 		FlagRush_Markers::FlagMarker_Remove();
@@ -240,7 +246,7 @@ Void Drop(Vec3 Position, Integer CurrentStateEndDate) {
 /**
  * Sets the new flag carrier and also tracks the last pass.
  */
-Void Pass(CSmPlayer NewCarrier, Integer CurrentStateEndDate) {
+Void Pass(CSmPlayer NewCarrier, Integer CurrentStateEndDate, Boolean HasStealResistance) {
 	declare Boolean FlagRush_Debug for This;
 	if (FlagRush_Debug) {
 		assert(IsOnPlayer(), "Cannot pass a flag that is not being carried by anyone");
@@ -254,7 +260,7 @@ Void Pass(CSmPlayer NewCarrier, Integer CurrentStateEndDate) {
 		NewCarrier = Private_PlayerToStruct(NewCarrier),
 		Date = Now
 	};
-	SetAtCarrier(NewCarrier, CurrentStateEndDate);
+	SetAtCarrier(NewCarrier, CurrentStateEndDate, HasStealResistance);
 }
 
 /* Lifecycle */

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UIShared.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UIShared.Script.txt
@@ -91,6 +91,7 @@ Text GetFlagStateStructs() {
 			Vec3 Position;
 			Integer CurrentStateStartDate;
 			Integer CurrentStateEndDate;
+			Boolean HasStealResistance;
 		}
 	""";
 }

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Markers.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/Markers.Script.txt
@@ -240,10 +240,19 @@ Text GetManialink() {
 			}
 
 			// Gauge Animation
-			if (FlagRush_Net_FlagState.CurrentStateEndDate <= GameTime) {
+			declare Boolean TimerPassed = FlagRush_Net_FlagState.CurrentStateEndDate <= GameTime;
+			declare Boolean IsOpponentClan = GUIPlayer != Null && GUIPlayer.CurrentClan == 3 - FlagRush_Net_FlagState.Holder.Clan;
+			declare Boolean HasNoStealResistance = !FlagRush_Net_FlagState.HasStealResistance;
+			if (TimerPassed || IsOpponentClan && HasNoStealResistance) {
 				G_FlagMarker.Gauge.Frame.Hide();
 				G_FlagMarker.Icon.Opacity = 1.;
 			} else {
+				declare Vec3 Color = <1., 1., 1.>;
+				if (HasNoStealResistance) {
+					Color = GetTeamLightColor(FlagRush_Net_FlagState.Holder.Clan);
+				}
+				G_FlagMarker.Gauge.Left.Colorize = Color;
+				G_FlagMarker.Gauge.Right.Colorize =  Color;
 				declare Integer FlagStateDuration = FlagRush_Net_FlagState.CurrentStateEndDate - FlagRush_Net_FlagState.CurrentStateStartDate;
 				declare Integer FlagStateDurationRemaining = FlagRush_Net_FlagState.CurrentStateEndDate - GameTime;
 				declare Real Ratio;

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -72,6 +72,7 @@
 #Setting S_FlagDropStateDurationSeconds			8. 			as "<hidden>" // Flag drop state duration (seconds)
 #Setting S_FlagStealResistDurationSeconds		1. 			as "<hidden>" // Flag steal resistance (seconds)
 #Setting S_FlagSameTeamSteal								True		as "<hidden>" // Team flag steal
+#Setting S_FlagStealResistanceOnTeamPass    False   as "<hidden>" // Flag steal resistance on passes between players in same team
 #Setting S_FlagCarrierFragile								True		as "Flag carrier becomes fragile"
 #Setting S_FlagCarrierAcceleration					0.66 		as "Flag carrier acceleration (0.0 - 1.0)"
 #Setting S_FlagCarrierControl								1.0 		as "<hidden>" // Flag carrier steering control (0.0 - 1.0)
@@ -175,11 +176,15 @@ if (FlagRush_FlagState::IsDropped()) {
 
 // Try pass flag
 declare CSmPlayer FlagCarrier = FlagRush_FlagState::GetFlagCarrierPlayer();
-if (FlagCarrier != Null && Now > FlagRush_FlagState::Get().CurrentStateEndDate) {
+
+if (FlagCarrier != Null) {
 	declare CSmPlayer FlagReceiver = GetFirstCollidingPlayer_OpponentPriority(FlagCarrier);
 	if (FlagReceiver != Null) {
-		declare IsSameTeam = FlagCarrier.CurrentClan == FlagReceiver.CurrentClan;
-		if (S_FlagSameTeamSteal || !IsSameTeam) {
+		declare Boolean IsSameTeam = FlagCarrier.CurrentClan == FlagReceiver.CurrentClan;
+		declare Boolean TimerPassed = Now > FlagRush_FlagState::Get().CurrentStateEndDate;
+		declare Boolean SameTeamCanSteal = S_FlagSameTeamSteal && TimerPassed;
+		declare Boolean OpponentCanSteal = !FlagRush_FlagState::Get().HasStealResistance || TimerPassed;
+		if (IsSameTeam && SameTeamCanSteal || !IsSameTeam && OpponentCanSteal) {
 			FlagCarrier_PassFlag(FlagReceiver);
 		}
 	}
@@ -369,7 +374,7 @@ Boolean Player_CanPickUpDroppedFlag(CSmPlayer Player) {
 Void Player_PickUpFlag(CSmPlayer Player) {
 	FlagRush_Messages::FlagPickUp(Player, C_Duration_EventMessage);
 	declare Integer StealResistanceEndDate = Now + ML::NearestInteger(S_FlagStealResistDurationSeconds * 1000);
-	FlagRush_FlagState::SetAtCarrier(Player, StealResistanceEndDate);
+	FlagRush_FlagState::SetAtCarrier(Player, StealResistanceEndDate, True);
 	Player_ApplyHandicaps(Player);
 	FlagRush_XmlRpc::Send_FlagPickup();
 }
@@ -377,14 +382,15 @@ Void Player_PickUpFlag(CSmPlayer Player) {
 Void FlagCarrier_PassFlag(CSmPlayer Player) {
 	// Old Carrier
 	declare CSmPlayer OldCarrier = FlagRush_FlagState::GetFlagCarrierPlayer();
-	if (Player.CurrentClan != OldCarrier.CurrentClan) {
+	declare Boolean IsNotSameTeam = Player.CurrentClan != OldCarrier.CurrentClan;
+	if (IsNotSameTeam) {
 		FlagRush_Scores::OnPlayerStealFlag(Player);
 	}
 	Player_ResetHandicaps(OldCarrier);
 	// New Carrier
 	FlagRush_Messages::FlagPickUp(Player, C_Duration_EventMessage);
 	declare Integer StealResistanceEndDate = Now + ML::NearestInteger(S_FlagStealResistDurationSeconds * 1000);
-	FlagRush_FlagState::Pass(Player, StealResistanceEndDate);
+	FlagRush_FlagState::Pass(Player, StealResistanceEndDate, IsNotSameTeam || S_FlagStealResistanceOnTeamPass);
 	Player_ApplyHandicaps(Player);
 	FlagRush_XmlRpc::Send_FlagPass(OldCarrier);
 }

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -53,6 +53,10 @@
 
 #Const C_AssistTimeThreshold 5000
 
+#Const C_FlagDropPositionMode_CurrentPosition		"FlagDropPositionMode_CurrentPosition"
+#Const C_FlagDropPositionMode_PreviousPosition	"FlagDropPositionMode_PreviousPosition"
+#Const C_FlagDropPositionMode_LastSafePosition	"FlagDropPositionMode_LastSafePosition"
+
 // ======== //
 // Settings //
 // ======== //
@@ -145,10 +149,11 @@ FlagRush_Handicaps::Yield();
 FlagRush_FlagState::Yield();
 
 // Update Flag
-if (FlagRush_FlagState::CarrierDisconnected()) DropFlag();
+if (FlagRush_FlagState::CarrierDisconnected()) FlagCarrier_DropFlag();
+
 if (S_DropFlagOnTeleportDetection && FlagRush_FlagState::CarrierTeleported()) {
 	FlagRush_Messages::FlagCarrierTeleport();
-	DropFlag(FlagRush_FlagState::Get().PrevPosition);
+	FlagCarrier_DropFlag(C_FlagDropPositionMode_PreviousPosition);
 }
 
 if (FlagRush_FlagState::IsDropped()) {
@@ -157,32 +162,27 @@ if (FlagRush_FlagState::IsDropped()) {
 	} else { // Check for pickups
 		declare CSmPlayer NewCarrier;
 		foreach (Player in Players) {
-			if (Player_CanPickUpDroppedFlag(Player)) {
-				if (Player.CurrentClan != FlagRush_FlagState::Get().LastDrop.OldCarrier.Clan) { // Opponent clan priority
-					NewCarrier = Player;
-					break;
-				} else if (NewCarrier == Null) {
-					NewCarrier = Player;
-				}
-			}
+			if (!Player_CanPickUpDroppedFlag(Player)) continue;
+			declare Boolean IsSameTeam = Player.CurrentClan == FlagRush_FlagState::Get().LastDrop.OldCarrier.Clan;
+			if (NewCarrier != Null && IsSameTeam) continue;
+			NewCarrier = Player;
+			if (!IsSameTeam) break;
 		}
 
-		if (NewCarrier != Null) PickUpFlag(NewCarrier);
+		if (NewCarrier != Null) Player_PickUpFlag(NewCarrier);
 	}
 }
 
 // Try pass flag
 declare CSmPlayer FlagCarrier = FlagRush_FlagState::GetFlagCarrierPlayer();
 if (FlagCarrier != Null && Now > FlagRush_FlagState::Get().CurrentStateEndDate) {
-	declare CSmPlayer FlagReceiver;
-	foreach (Player in Players) {
-		if (Player == FlagCarrier || !Hitbox::AreColliding(FlagCarrier, Player)) continue;
-		declare Boolean IsSameTeam = Player.CurrentClan == FlagCarrier.CurrentClan;
-		if (IsSameTeam && (!S_FlagSameTeamSteal || FlagReceiver != Null)) continue; // Opponent flag steal priority
-		FlagReceiver = Player;
-		if (!IsSameTeam) break; // No need to look further if opponent player was found
+	declare CSmPlayer FlagReceiver = GetFirstCollidingPlayer_OpponentPriority(FlagCarrier);
+	if (FlagReceiver != Null) {
+		declare IsSameTeam = FlagCarrier.CurrentClan == FlagReceiver.CurrentClan;
+		if (S_FlagSameTeamSteal || !IsSameTeam) {
+			FlagCarrier_PassFlag(FlagReceiver);
+		}
 	}
-	if (FlagReceiver != Null) PassFlag(FlagReceiver);
 }
 
 foreach (Event in PendingEvents) {
@@ -276,6 +276,18 @@ if (
 // Functions //
 // ========= //
 
+CSmPlayer GetFirstCollidingPlayer_OpponentPriority(CSmPlayer ReferencePlayer) {
+	declare CSmPlayer FirstCollidingPlayer;
+	foreach (Player in Players) {
+		if (Player == ReferencePlayer || !Hitbox::AreColliding(ReferencePlayer, Player)) continue;
+		declare Boolean IsSameTeam = Player.CurrentClan == ReferencePlayer.CurrentClan;
+		if (FirstCollidingPlayer != Null && IsSameTeam) continue;
+		FirstCollidingPlayer = Player;
+		if (!IsSameTeam) return FirstCollidingPlayer;
+	}
+	return FirstCollidingPlayer;
+}
+
 Void Flag_Reset(Boolean Silent) {
 	if (!Silent) FlagRush_Messages::FlagReset(C_Duration_EventMessage);
 
@@ -354,11 +366,7 @@ Boolean Player_CanPickUpDroppedFlag(CSmPlayer Player) {
 	return (DidNotDropFlag || DropPickupPenaltyExpired) && Hitbox::AreColliding(Player, FlagRush_FlagState::Get().Position);
 }
 
-// ================================================= //
-// Actions: Things that can be performed by a player //
-// ================================================= //
-
-Void PickUpFlag(CSmPlayer Player) {
+Void Player_PickUpFlag(CSmPlayer Player) {
 	FlagRush_Messages::FlagPickUp(Player, C_Duration_EventMessage);
 	declare Integer StealResistanceEndDate = Now + ML::NearestInteger(S_FlagStealResistDurationSeconds * 1000);
 	FlagRush_FlagState::SetAtCarrier(Player, StealResistanceEndDate);
@@ -366,7 +374,7 @@ Void PickUpFlag(CSmPlayer Player) {
 	FlagRush_XmlRpc::Send_FlagPickup();
 }
 
-Void PassFlag(CSmPlayer Player) {
+Void FlagCarrier_PassFlag(CSmPlayer Player) {
 	// Old Carrier
 	declare CSmPlayer OldCarrier = FlagRush_FlagState::GetFlagCarrierPlayer();
 	if (Player.CurrentClan != OldCarrier.CurrentClan) {
@@ -381,45 +389,71 @@ Void PassFlag(CSmPlayer Player) {
 	FlagRush_XmlRpc::Send_FlagPass(OldCarrier);
 }
 
-Void DropFlag(Vec3 Position) {
-	// Save drop date
-	declare CSmPlayer OldCarrierPlayer = FlagRush_FlagState::GetFlagCarrierPlayer();
-	if (OldCarrierPlayer != Null) { // Could be due to disconnect
-		declare Integer FlagRush_LastFlagDropDate for OldCarrierPlayer;
-		FlagRush_LastFlagDropDate = Now;
-		Player_ResetHandicaps(OldCarrierPlayer);
+Void FlagCarrier_DropFlag(Text FlagDropPositionMode) {
+	declare CSmPlayer CarrierPlayer = FlagRush_FlagState::GetFlagCarrierPlayer();
+
+	// If manual dropping in player stack, do a pass instead
+	if (CarrierPlayer != Null && FlagDropPositionMode == C_FlagDropPositionMode_CurrentPosition) {
+		declare CSmPlayer ReceiverPlayer = GetFirstCollidingPlayer_OpponentPriority(CarrierPlayer);
+		if (ReceiverPlayer != Null) {
+			FlagCarrier_PassFlag(ReceiverPlayer);
+			return;
+		}
 	}
 
-	declare CUser OldCarrierUser = ModeUtils::GetUser(FlagRush_FlagState::Get().Carrier.Login);
-	FlagRush_Messages::FlagDropped(OldCarrierUser, C_Duration_EventMessage);
+	// Determine Position
+	declare Vec3 Position;
+	switch (FlagDropPositionMode) {
+		case C_FlagDropPositionMode_PreviousPosition: {
+			Position = FlagRush_FlagState::Get().PrevPosition;
+		}
+		case C_FlagDropPositionMode_LastSafePosition: {
+			Position = FlagRush_FlagState::Get().LastSafePosition;
+		}
+		default: {
+			if (CarrierPlayer != Null) {
+				Position = CarrierPlayer.Position;
+			} else {
+				Position = FlagRush_FlagState::Get().Position;
+			}
+		}
+	}
+
+	// Reset player
+	if (CarrierPlayer != Null) {
+		Player_ResetHandicaps(CarrierPlayer);
+		declare Integer FlagRush_LastFlagDropDate for CarrierPlayer;
+		FlagRush_LastFlagDropDate = Now;
+	}
+
+	declare CUser CarrierUser = ModeUtils::GetUser(FlagRush_FlagState::Get().Carrier.Login);
 	declare DropStateEndDate = Now + ML::NearestInteger(S_FlagDropStateDurationSeconds * 1000);
 	FlagRush_FlagState::Drop(Position, DropStateEndDate);
-	FlagRush_XmlRpc::Send_FlagDrop(OldCarrierUser);
+	FlagRush_Messages::FlagDropped(CarrierUser, C_Duration_EventMessage);
+	FlagRush_XmlRpc::Send_FlagDrop(CarrierUser);
 }
 
-Void DropFlag() {
-	declare CSmPlayer OldCarrierPlayer = FlagRush_FlagState::GetFlagCarrierPlayer();
-	declare Vec3 Position;
-	if (OldCarrierPlayer != Null) Position = OldCarrierPlayer.Position;
-	else Position = FlagRush_FlagState::Get().Position;
-	DropFlag(Position);
+Void FlagCarrier_DropFlag() {
+	FlagCarrier_DropFlag(C_FlagDropPositionMode_CurrentPosition);
 }
 
-Void ScoreFlag(CSmPlayer Player) {
-	FlagRush_Messages::FlagScored(Player, C_Duration_EventMessage);
-	FlagRush_Scores::OnPlayerScoreFlag(Player.Score);
+Void FlagCarrier_ScoreFlag() {
+	declare CSmPlayer CarrierPlayer = FlagRush_FlagState::GetFlagCarrierPlayer();
+	FlagRush_Messages::FlagScored(CarrierPlayer, C_Duration_EventMessage);
+	FlagRush_Scores::OnPlayerScoreFlag(CarrierPlayer.Score);
+
 	// Check for assist
 	declare FlagRush_FlagState::K_FlagPass LastPass = FlagRush_FlagState::Get().LastFlagPass;
 	declare CUser Assist;
 	if (Now - LastPass.Date <= C_AssistTimeThreshold && LastPass.OldCarrier.PlayerId != NullId) {
 		declare CSmScore AssistScore <=> ModeUtils::GetScore(LastPass.OldCarrier.Login);
-		if (AssistScore.TeamNum == Player.Score.TeamNum) {
+		if (AssistScore.TeamNum == CarrierPlayer.Score.TeamNum) {
 			Assist = AssistScore.User;
 			FlagRush_Scores::OnPlayerScoreFlagAssist(AssistScore);
 		}
 	}
-	Player_ResetHandicaps(Player);
-	FlagRush_XmlRpc::Send_FlagScored(Player, Assist);
+	Player_ResetHandicaps(CarrierPlayer);
+	FlagRush_XmlRpc::Send_FlagScored(CarrierPlayer, Assist);
 	Flag_Reset(True);
 	if (S_UseTurns) MB_StopTurn();
 }
@@ -429,14 +463,14 @@ Void ScoreFlag(CSmPlayer Player) {
 // =========================================================== //
 
 Void OnPlayerRequestsClanChange(CSmPlayer Player) {
-	if (Player == FlagRush_FlagState::GetFlagCarrierPlayer()) DropFlag();
+	if (Player == FlagRush_FlagState::GetFlagCarrierPlayer()) FlagCarrier_DropFlag();
 	Player_Unspawn(Player);
 	SetPlayerClan(Player, Player.RequestedClan);
 }
 
 Void OnPlayerRequestsRespawn(CSmPlayer Player) {
 	if (Player == FlagRush_FlagState::GetFlagCarrierPlayer()) {
-		DropFlag();
+		FlagCarrier_DropFlag();
 		return;
 	}
 
@@ -455,7 +489,7 @@ Void OnPlayerRequestsRespawn(CSmPlayer Player) {
 
 Void OnPlayerDeath(CSmPlayer Player) {
 	if (Player == FlagRush_FlagState::GetFlagCarrierPlayer()) {
-		DropFlag();
+		FlagCarrier_DropFlag();
 	}
 	FlagRush_XmlRpc::Send_PlayerDeath(Player);
 	Player_Unspawn(Player);
@@ -464,7 +498,7 @@ Void OnPlayerDeath(CSmPlayer Player) {
 Void OnPlayerOutOfBound(CSmPlayer Player) {
 	FlagRush_Messages::PlayerOutOfBounds(Player);
 	if (Player == FlagRush_FlagState::GetFlagCarrierPlayer()) {
-		DropFlag(FlagRush_FlagState::Get().LastSafePosition);
+		FlagCarrier_DropFlag(C_FlagDropPositionMode_LastSafePosition);
 	}
 	FlagRush_XmlRpc::Send_PlayerDeath(Player);
 	Player_Unspawn(Player);
@@ -474,7 +508,7 @@ Void OnPlayerTriggersWaypoint(CSmPlayer Player, CMapLandmark Landmark) {
 	if (FlagRush_Map::IsOutOfBoundsTrigger(Landmark)) {
 		OnPlayerOutOfBound(Player);
 	} else if (FlagRush_FlagState::Get().Landmark == Landmark && Now > FlagRush_FlagState::Get().CurrentStateEndDate) {
-		PickUpFlag(Player);
+		Player_PickUpFlag(Player);
 	} else if (Player == FlagRush_FlagState::GetFlagCarrierPlayer()){
 		declare Integer TargetBaseClan;
 		if (S_UseReversedBases) {
@@ -483,7 +517,7 @@ Void OnPlayerTriggersWaypoint(CSmPlayer Player, CMapLandmark Landmark) {
 			TargetBaseClan = 3 - Player.CurrentClan;
 		}
 		if (FlagRush_Map::GetBases(TargetBaseClan).exists(Landmark)) {
-			ScoreFlag(Player);
+			FlagCarrier_ScoreFlag();
 		}
 	}
 }


### PR DESCRIPTION
In order to nerf flag relays, the following changes have been made:
- Manually dropping the flag in a stack of players is no longer considered a drop, but instead a pass/steal.
- No more flag steal resistance on passes between team members
- Picking up a dropped flag or stealing it from your opponent still gives steal resistance.
- Steal resistance can still be triggered by dropping the flag in front of your teammate who will pick it up at least 1 server frame later.
- A setting has been added to switch this behaviour (`S_FlagStealResistanceOnTeamPass`)