### PR TITLE
Remove deprecated CUIConfig properties

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UI.Script.txt
@@ -41,10 +41,7 @@ Void Private_LoadUIAll() {
 
 	UIManager.UIAll.OverlayHideNotices = True;
 	UIManager.UIAll.OverlayHideMapInfo = True;
-	UIManager.UIAll.OverlayHideOpponentsInfo = True; // ?
 	UIManager.UIAll.OverlayHideChat = False;
-	UIManager.UIAll.OverlayHideCheckPointList = True;
-	UIManager.UIAll.OverlayHideRoundScores = True;
 	UIManager.UIAll.OverlayHideCountdown = True;
 	UIManager.UIAll.OverlayHideCrosshair = True;
 	UIManager.UIAll.OverlayHideGauges = True;

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UI.Script.txt
@@ -51,17 +51,8 @@ Void Private_LoadUIAll() {
 	UIManager.UIAll.OverlayHideConsumables = True;
 	UIManager.UIAll.OverlayHide321Go = True;
 	UIManager.UIAll.OverlayMute321Go = False;
-	UIManager.UIAll.OverlayHideBackground = True; // ?
-	UIManager.UIAll.OverlayHideChrono = True;
-	UIManager.UIAll.OverlayHideSpeedAndDist = True;
-	UIManager.UIAll.OverlayHidePersonnalBestAndRank = True;
-	UIManager.UIAll.OverlayHidePosition = True;
-	UIManager.UIAll.OverlayHideCheckPointTime = True;
 	UIManager.UIAll.OverlayHideEndMapLadderRecap = True;
-	UIManager.UIAll.OverlayHideMultilapInfos = True;
-	UIManager.UIAll.OverlayHideSpectatorControllers = True;
 	UIManager.UIAll.OverlayHideSpectatorInfos = True;
-	UIManager.UIAll.OverlayChatHideAvatar = True;
 
 	UIManager.UIAll.ScoreTableOnlyManialink = True; // Hide default simple score board
 


### PR DESCRIPTION
Removes some CUIConfig parameters that are removed from the API in an upcoming update.

Waiting for that update to confirm that changes work as instended and script still compiles.