### PR TITLE
Null-check player on waypoint events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 + Added a toggle button on the scoreboard to toggle between displaying map or match scores.
 + Fixed podium screen after december Trackmania update.
 
+### Bugs and crashes
+* Fixed a bug that causes a flag marker to be stuck in the center of the screen during initial warmup per map.
+* Fixed a crash that happened when a player leaves the server at the same server frame as crossing a waypoint.
+
 ---
 
 ## 1.3.2

--- a/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/Trackmania/FlagRush.Script.txt
@@ -191,8 +191,14 @@ if (FlagCarrier != Null) {
 
 foreach (Event in PendingEvents) {
 	switch (Event.Type) {
-		case CSmModeEvent::EType::OnPlayerTriggersWaypoint: OnPlayerTriggersWaypoint(Event.Player, Event.Landmark);
-		case CSmModeEvent::EType::OnPlayerRequestRespawn: OnPlayerRequestsRespawn(Event.Player);
+		case CSmModeEvent::EType::OnPlayerTriggersWaypoint: {
+			// Player might have left in the same server frame, causing Player to be Null
+			if (Event.Player != Null) OnPlayerTriggersWaypoint(Event.Player, Event.Landmark);
+		}
+		case CSmModeEvent::EType::OnPlayerRequestRespawn: {
+			// Player might have left in the same server frame, causing Player to be Null
+			if (Event.Player != Null) OnPlayerRequestsRespawn(Event.Player);
+		}
 		case CSmModeEvent::EType::OnCommand: OnGameplayCommand(CommandUtils::FromEvent(Event)); // Commands from Mode (Settings or XmlRpc)
 	}
 }
@@ -230,10 +236,12 @@ foreach (Player in Players) {
 foreach (Event in PendingEvents) {
 	switch (Event.Type) {
 		case CSmModeEvent::EType::OnPlayerRequestRespawn: {
-			UnspawnPlayer(Event.Player);
+			// Player might have left in the same server frame, causing Player to be Null
+			if (Event.Player != Null) UnspawnPlayer(Event.Player);
 		}
 		case CSmModeEvent::EType::OnPlayerTriggersWaypoint: {
-			if (FlagRush_Map::IsOutOfBoundsTrigger(Event.Landmark)) {
+			// Player might have left in the same server frame, causing Player to be Null
+			if (Event.Player != Null && FlagRush_Map::IsOutOfBoundsTrigger(Event.Landmark)) {
 				FlagRush_Messages::PlayerOutOfBounds(Event.Player);
 				UnspawnPlayer(Event.Player);
 			}


### PR DESCRIPTION
Closes #248 

When a player leaves the server in the same server frame as triggering a checkpoint or requesting a respawn, then the according events will report the player as Null. This can cause script crashes due to NPEs. Therefore, the events are checked for Null now.