### PR TITLE
Fix flag marker car overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 	* Split flag marker gauge intoo two separate gauges:
 		1. Ring gauge around the flag to indicate the lock state ("steal resistance")
 		2. Circular background gauge behind the flag to indicate the drop reset timer
+	* Added a fake shadow below the flag marker when in dropped state
 
 ---
 

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
@@ -1,15 +1,22 @@
 #Include "Libs/Nadeo/CMGame/Modes/Legacy/Layers2.Script.txt" as Layers
 
 #Include "Libs/Zrx/ModeLibs/FlagRush/Flag.Script.txt" as Flag
+#Include "Libs/Zrx/ModeLibs/FlagRush/FlagRush_Vehicle.Script.txt" as Vehicles
 #Include "Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UIShared.Script.txt" as Shared
 
 #Const C_LayerName "FlagRush_FlagMarker"
-
 #Const C_FrameId "FlagRush_Marker_Flag"
 
-#Const C_Box_Player		<0., 0.25, 0.>
-#Const C_Box_Landmark	<0., 1., 0.>
-#Const C_Box_Position	<0., 0.25, 0.>
+#Const Vehicles::C_Vehicle_Snow as C_Vehicle_Snow
+#Const Vehicles::C_Vehicle_Rally as C_Vehicle_Rally
+
+// Boxes are adjusted to be slightly above the highest part of the respective model when on flat ground
+// Vertical 0.0 is not on the ground but slightly above player head; negative values not possible
+#Const C_Box_Player_Stadium		<0., 0., 0.>
+#Const C_Box_Player_Snow			<0., 0.4, 0.>
+#Const C_Box_Player_Rally 		<0., 0.25, 0.>
+#Const C_Box_Landmark					<0., 1., 0.>
+#Const C_Box_Position					<0., 0.25, 0.>
 
 declare Ident G_MarkerId;
 
@@ -18,40 +25,42 @@ Text GetManialink() {
 <manialink version="3" name="{{{ C_LayerName }}}">
 	<frame z-index="2"> <!-- Display flag marker over other markers (highest z-index) -->
 		<frame id="{{{ C_FrameId }}}" scale="0.9" hidden="1"> <!-- Initialize as hidden; Markers will show it automatically -->
-			<frame id="flag">
-				<quad id="icon" pos="0 0" size="10 10" halign="center" valign="center" style="UICommon64_1" substyle="Flag_light"/>
-				<quad id="icon-dropshadow" pos="0.25 -0.25" z-index="-1" size="10 10" halign="center" valign="center" style="UICommon64_1" substyle="Flag_dark"/>
-			</frame>
+			<frame id="botom-align-offset" pos="0 5">
+				<frame id="flag">
+					<quad id="icon" pos="0 0" size="10 10" halign="center" valign="center" style="UICommon64_1" substyle="Flag_light"/>
+					<quad id="icon-dropshadow" pos="0.25 -0.25" z-index="-1" size="10 10" halign="center" valign="center" style="UICommon64_1" substyle="Flag_dark"/>
+				</frame>
 
-			<label id="distance" pos="0 3.5" size="10 5" halign="center" valign="center2" textfont="GameFontSemiBold" textsize="0.4" textemboss="1" text="2500m"/>
+				<label id="distance" pos="0 3.5" size="10 5" halign="center" valign="center2" textfont="GameFontSemiBold" textsize="0.4" textemboss="1" text="2500m"/>
 
-			<frame id="height-indicator">
-				<quad id="up" pos="0 8" size="6 6" style="UICommon64_2" substyle="ArrowUpSlim_light" halign="center" valign="center" />
-				<quad id="down" pos="0 -8" size="6 6" style="UICommon64_2" substyle="ArrowDownSlim_light" halign="center" valign="center"/>
-			</frame>
+				<frame id="height-indicator">
+					<quad id="up" pos="0 8" size="6 6" style="UICommon64_2" substyle="ArrowUpSlim_light" halign="center" valign="center" />
+					<quad id="down" pos="0 -8" size="6 6" style="UICommon64_2" substyle="ArrowDownSlim_light" halign="center" valign="center"/>
+				</frame>
 
-			<frame id="lock">
-				<label id="status" pos="6 0" z-index="1" halign="center" valign="center2" text="" textemboss="1" textsize="2.5" size="8 8"/>
-				<frame id="gauge">
-					<frame size="80 160" pos="0 0" halign="right" valign="center">
-						<quad id="left" pos="0 0" valign="center" halign="right" size="8 16" colorize="FFF" image="file://Media/Manialinks/Nadeo/Trackmania/Ingame/NewSpeed-gauge1.dds"/>
-					</frame>
-					<frame size="80 160" pos="0 0" halign="right" valign="center" rot="180">
-						<quad id="right" pos="0 0" valign="center" halign="right" size="8 16" colorize="FFF" image="file://Media/Manialinks/Nadeo/Trackmania/Ingame/NewSpeed-gauge1.dds"/>
+				<frame id="lock">
+					<label id="status" pos="6 0" z-index="1" halign="center" valign="center2" text="" textemboss="1" textsize="2.5" size="8 8"/>
+					<frame id="gauge">
+						<frame size="80 160" pos="0 0" halign="right" valign="center">
+							<quad id="left" pos="0 0" valign="center" halign="right" size="8 16" colorize="FFF" image="file://Media/Manialinks/Nadeo/Trackmania/Ingame/NewSpeed-gauge1.dds"/>
+						</frame>
+						<frame size="80 160" pos="0 0" halign="right" valign="center" rot="180">
+							<quad id="right" pos="0 0" valign="center" halign="right" size="8 16" colorize="FFF" image="file://Media/Manialinks/Nadeo/Trackmania/Ingame/NewSpeed-gauge1.dds"/>
+						</frame>
 					</frame>
 				</frame>
-			</frame>
 
-			<frame id="drop-gauge" valign="bottom" halign="center" size="12 12" pos="0 -6" z-index="-1">
-					<quad id="background" pos="0 0" valign="bottom" halign="center" size="12 12" modulatecolor="fff" opacity="0.66" image="file://Media/Painter/Stencils/01-EllipseRound/Brush.tga"/>
-			</frame>
+				<frame id="drop-gauge" valign="bottom" halign="center" size="12 12" pos="0 -6" z-index="-1">
+						<quad id="background" pos="0 0" valign="bottom" halign="center" size="12 12" modulatecolor="fff" opacity="0.66" image="file://Media/Painter/Stencils/01-EllipseRound/Brush.tga"/>
+				</frame>
 
-			<!--
-				Changing visibility or ratation of elements causes the bounding box size of the marker to vary.
-				When at the border of the screen as the game tries to move it as close to the border as possible, which can cause jumping (when chaging element visibility) or bouncing (when rotating/moving elements).
-				This quad is slightly bigger than the bounding box of all other elements combined, therefore preventing the bouncing. Cannot be hidden, but opacity 0.
-			-->
-			<quad id="nobounce" size="22.75 22.75" opacity="0" halign="center" valign="center"/>
+				<!--
+					Changing visibility or ratation of elements causes the bounding box size of the marker to vary.
+					When at the border of the screen as the game tries to move it as close to the border as possible, which can cause jumping (when chaging element visibility) or bouncing (when rotating/moving elements).
+					This quad is slightly bigger than the bounding box of all other elements combined, therefore preventing the bouncing. Cannot be hidden, but opacity 0.
+				-->
+				<quad id="nobounce" size="22.75 22.75" halign="center" valign="center"/>
+			</frame>
 		</frame>
 	</frame>
 
@@ -96,6 +105,7 @@ Text GetManialink() {
 
 #Struct K_FlagMarker {
 	CMlFrame Frame;
+	CMlFrame OffsetFrame;
 	K_FlagIcon FlagIcon;
 	CMlLabel DistanceLabel;
 	K_HeightIndicator HeightIndicator;
@@ -114,6 +124,7 @@ Real Progress(Integer _From, Integer _To, Integer _Current) {
 
 Void Init() {
 	G_FlagMarker.Frame = (Page.GetFirstChild("{{{ C_FrameId }}}") as CMlFrame);
+	G_FlagMarker.OffsetFrame = (G_FlagMarker.Frame.GetFirstChild("botom-align-offset") as CMlFrame);
 	G_FlagMarker.DistanceLabel = (G_FlagMarker.Frame.GetFirstChild("distance") as CMlLabel);
 
 	declare K_FlagIcon FlagIcon;
@@ -215,6 +226,15 @@ Void UpdateDropGauge() {
 	G_FlagMarker.DropGauge.Frame.Visible = DisplayDropGauge;
 }
 
+Void UpdateOffset() {
+	declare netread K_Net_Flag FlagRush_Net_Flag for Teams[0] = K_Net_Flag{};
+	if (FlagRush_Net_Flag.Location.Player.Login != "") {
+		G_FlagMarker.OffsetFrame.RelativePosition_V3.Y = G_FlagMarker.FlagIcon.IconQuad.Size.Y / 2.0;
+	} else {
+		G_FlagMarker.OffsetFrame.RelativePosition_V3.Y = 0.0;
+	}
+}
+
 main() {
 	Init();
 	while(True) {
@@ -226,6 +246,7 @@ main() {
 		UpdateDistanceIndicators();
 		UpdateLock();
 		UpdateDropGauge();
+		UpdateOffset();
 	}
 }
 	--></script>
@@ -270,7 +291,17 @@ Void Private_SetAtPlayer(CSmPlayer _Player) {
 	Private_Remove();
 	declare CUIConfigMarker Marker = UIManager.UIAll.AddMarker(_Player);
 	G_MarkerId = Marker.Id;
-	Marker.Box = C_Box_Player;
+	switch (_Player.ForceModelId) {
+		case Vehicles::GetItemId(C_Vehicle_Snow.Id): {
+			Marker.Box = C_Box_Player_Snow;
+		}
+		case Vehicles::GetItemId(C_Vehicle_Rally.Id): {
+			Marker.Box = C_Box_Player_Rally;
+		}
+		default: {
+			Marker.Box = C_Box_Player_Stadium;
+		}
+	}
 	Marker.ManialinkFrameId = C_FrameId;
 	Marker.HudVisibility = CUIConfigMarker::EHudVisibility::Always;
 }

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
@@ -6,6 +6,7 @@
 
 #Const C_LayerName "FlagRush_FlagMarker"
 #Const C_FrameId "FlagRush_Marker_Flag"
+#Const C_FrameId_ShadowVisibilityMarker "FlagRush_Marker_FlagShadowVisibility"
 
 #Const Vehicles::C_Vehicle_Snow as C_Vehicle_Snow
 #Const Vehicles::C_Vehicle_Rally as C_Vehicle_Rally
@@ -15,17 +16,25 @@
 #Const C_Box_Player_Stadium		<0., 0., 0.>
 #Const C_Box_Player_Snow			<0., 0.4, 0.>
 #Const C_Box_Player_Rally 		<0., 0.25, 0.>
-#Const C_Box_Landmark					<0., 1., 0.>
-#Const C_Box_Position					<0., 0.25, 0.>
+#Const C_Box_Landmark					<0., 0., 0.>
+#Const C_Box_Position					<0., 0., 0.>
 
 declare Ident G_MarkerId;
+declare Ident G_ShadowVisibilityMarkerId;
 
 Text GetManialink() {
 	return """<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <manialink version="3" name="{{{ C_LayerName }}}">
-	<frame z-index="2"> <!-- Display flag marker over other markers (highest z-index) -->
+
+	<frame z-index="2">
+		<frame id="{{{ C_FrameId_ShadowVisibilityMarker }}}" hidden="1"></frame>
+	</frame>
+
+	<frame z-index="3"> <!-- Display flag marker over other markers (highest z-index) -->
 		<frame id="{{{ C_FrameId }}}" scale="0.9" hidden="1"> <!-- Initialize as hidden; Markers will show it automatically -->
-			<frame id="botom-align-offset" pos="0 5">
+			<frame id="botom-align-offset" pos="0 5"> <!-- Flag icon height / 2 -->
+				<quad id="flag-shadow" pos="0 -5" z-index="-2" size="1 1" halign="center" valign="center" style="Bgs1InRace" substyle="BgShadow" hidden="1"/>
+
 				<frame id="flag">
 					<quad id="icon" pos="0 0" size="10 10" halign="center" valign="center" style="UICommon64_1" substyle="Flag_light"/>
 					<quad id="icon-dropshadow" pos="0.25 -0.25" z-index="-1" size="10 10" halign="center" valign="center" style="UICommon64_1" substyle="Flag_dark"/>
@@ -71,6 +80,12 @@ Text GetManialink() {
 #Const C_HeightIndicatorThreshold 7. // Less than one block (8m) to prevent potential flickering on one block height differences
 #Const C_FlagIconOffset -1.
 #Const C_DropGaugeSize 12.
+#Const C_FlagShadowFadeDistance_Near 0.
+#Const C_FlagShadowFadeDistance_Far 3.
+#Const C_FlagShadowScale_Base 250.
+#Const C_FlagShadowScale_Max 50.
+#Const C_FlagShadowHeightRatio_Max 0.7
+#Const C_Epsilon 0.001
 
 {{{ Flag::DumpNetFlagStructs() }}}
 
@@ -106,6 +121,7 @@ Text GetManialink() {
 #Struct K_FlagMarker {
 	CMlFrame Frame;
 	CMlFrame OffsetFrame;
+	CMlQuad FlagShadowQuad;
 	K_FlagIcon FlagIcon;
 	CMlLabel DistanceLabel;
 	K_HeightIndicator HeightIndicator;
@@ -114,17 +130,25 @@ Text GetManialink() {
 }
 
 declare K_FlagMarker G_FlagMarker;
+declare CMlFrame G_FlagMarkerVisibilityMarker;
 
 {{{ Shared::GetTeamColorNetreadFunctions() }}}
 
-Real Progress(Integer _From, Integer _To, Integer _Current) {
-	declare Real Progress = 1.0 * (_Current - _From) / (_To - _From);
-	return ML::Clamp(Progress, 0.0, 1.0);
+Real Lerp01(Real _From, Real _To, Real _T) {
+	declare Real Lerp = (_T - _From) / (_To - _From);
+	return ML::Clamp(Lerp, 0.0, 1.0);
+}
+
+Real Lerp01(Integer _From, Integer _To, Integer _T) {
+	return Lerp01(ML::ToReal(_From), ML::ToReal(_To), ML::ToReal(_T));
 }
 
 Void Init() {
+	G_FlagMarkerVisibilityMarker = (Page.GetFirstChild("{{{ C_FrameId_ShadowVisibilityMarker }}}") as CMlFrame);
+
 	G_FlagMarker.Frame = (Page.GetFirstChild("{{{ C_FrameId }}}") as CMlFrame);
 	G_FlagMarker.OffsetFrame = (G_FlagMarker.Frame.GetFirstChild("botom-align-offset") as CMlFrame);
+	G_FlagMarker.FlagShadowQuad = (Page.GetFirstChild("flag-shadow") as CMlQuad);
 	G_FlagMarker.DistanceLabel = (G_FlagMarker.Frame.GetFirstChild("distance") as CMlLabel);
 
 	declare K_FlagIcon FlagIcon;
@@ -168,6 +192,7 @@ Void UpdateDistanceIndicators() {
 		G_FlagMarker.HeightIndicator.UpQuad.Hide();
 		G_FlagMarker.HeightIndicator.DownQuad.Hide();
 		G_FlagMarker.FlagIcon.Frame.RelativePosition_V3.Y = 0.;
+		G_FlagMarker.FlagShadowQuad.Hide();
 	} else { // Playing or spectating a non-carrier player
 		declare Vec3 Displacement = FlagRush_Net_Flag.Location.Position - GUIPlayer.Position;
 		declare Real Distance = ML::Length(Displacement);
@@ -177,6 +202,12 @@ Void UpdateDistanceIndicators() {
 
 		G_FlagMarker.HeightIndicator.UpQuad.Visible = Displacement.Y > C_HeightIndicatorThreshold;
 		G_FlagMarker.HeightIndicator.DownQuad.Visible = Displacement.Y < -C_HeightIndicatorThreshold;
+
+		G_FlagMarker.FlagShadowQuad.Visible = G_FlagMarkerVisibilityMarker.Visible;
+		if (G_FlagMarker.FlagShadowQuad.Visible) {
+			G_FlagMarker.FlagShadowQuad.RelativeScale = ML::Min(C_FlagShadowScale_Base / (Distance + C_Epsilon), C_FlagShadowScale_Max);
+			G_FlagMarker.FlagShadowQuad.Size.Y = ML::Min(1. / (Distance + C_Epsilon), C_FlagShadowHeightRatio_Max);
+		}
 	}
 }
 
@@ -205,7 +236,7 @@ Void UpdateLock() {
 	}
 
 	if (DisplayLock) {
-		declare Real GaugeProgress = Progress(FlagRush_Net_Flag.Lock.Timer.Since, FlagRush_Net_Flag.Lock.Timer.Until, ArenaNow);
+		declare Real GaugeProgress = Lerp01(FlagRush_Net_Flag.Lock.Timer.Since, FlagRush_Net_Flag.Lock.Timer.Until, ArenaNow);
 		declare Real LeftProgress = ML::Min(GaugeProgress * 2, 1.0);
 		declare Real RightProgress = ML::Max((GaugeProgress - 0.5) * 2, 0.0);
 		G_FlagMarker.Lock.Gauge.LeftQuad.RelativeRotation = LeftProgress * -180;
@@ -220,19 +251,10 @@ Void UpdateDropGauge() {
 	declare Boolean DisplayDropGauge = FlagRush_Net_Flag.Drop.Timer.Until > ArenaNow;
 
 	if (DisplayDropGauge) {
-		declare Real GaugeProgress = Progress(FlagRush_Net_Flag.Drop.Timer.Since, FlagRush_Net_Flag.Drop.Timer.Until, ArenaNow);
+		declare Real GaugeProgress = Lerp01(FlagRush_Net_Flag.Drop.Timer.Since, FlagRush_Net_Flag.Drop.Timer.Until, ArenaNow);
 		G_FlagMarker.DropGauge.Frame.Size.Y = (1 - GaugeProgress) * C_DropGaugeSize;
 	}
 	G_FlagMarker.DropGauge.Frame.Visible = DisplayDropGauge;
-}
-
-Void UpdateOffset() {
-	declare netread K_Net_Flag FlagRush_Net_Flag for Teams[0] = K_Net_Flag{};
-	if (FlagRush_Net_Flag.Location.Player.Login != "") {
-		G_FlagMarker.OffsetFrame.RelativePosition_V3.Y = G_FlagMarker.FlagIcon.IconQuad.Size.Y / 2.0;
-	} else {
-		G_FlagMarker.OffsetFrame.RelativePosition_V3.Y = 0.0;
-	}
 }
 
 main() {
@@ -246,7 +268,6 @@ main() {
 		UpdateDistanceIndicators();
 		UpdateLock();
 		UpdateDropGauge();
-		UpdateOffset();
 	}
 }
 	--></script>
@@ -255,15 +276,21 @@ main() {
 
 // Helpers
 
-CUIConfigMarker Private_GetMarker() {
-	return UIManager.UIAll.Markers.get(G_MarkerId, Null);
+CUIConfigMarker Private_GetMarker(Ident _Id) {
+	return UIManager.UIAll.Markers.get(_Id, Null);
 }
 
 Void Private_Remove() {
-	declare CUIConfigMarker Marker = Private_GetMarker();
+	declare CUIConfigMarker Marker = Private_GetMarker(G_MarkerId);
 	G_MarkerId = NullId;
 	if (Marker != Null) {
 		UIManager.UIAll.RemoveMarker(Marker);
+	}
+
+	declare CUIConfigMarker ShadowMarker = Private_GetMarker(G_ShadowVisibilityMarkerId);
+	G_ShadowVisibilityMarkerId = NullId;
+	if (ShadowMarker != Null) {
+		UIManager.UIAll.RemoveMarker(ShadowMarker);
 	}
 }
 
@@ -274,6 +301,13 @@ Void Private_SetAtPosition(Vec3 _Position) {
 	Marker.Box = C_Box_Position;
 	Marker.ManialinkFrameId = C_FrameId;
 	Marker.HudVisibility = CUIConfigMarker::EHudVisibility::Always;
+
+	// Dummy marker without content to track if flag marker is currently in view. Used to toggle flag shadow
+	declare CUIConfigMarker ShadowMarker = UIManager.UIAll.AddMarker(_Position);
+	G_ShadowVisibilityMarkerId = ShadowMarker.Id;
+	ShadowMarker.Box = C_Box_Position;
+	ShadowMarker.ManialinkFrameId = C_FrameId_ShadowVisibilityMarker;
+	ShadowMarker.HudVisibility = CUIConfigMarker::EHudVisibility::WhenInFrustum;
 }
 
 Void Private_SetAtLandmark(CMapLandmark _Landmark) {
@@ -307,19 +341,25 @@ Void Private_SetAtPlayer(CSmPlayer _Player) {
 }
 
 Void Hide() {
-	declare CUIConfigMarker Marker = Private_GetMarker();
-	if (Marker == Null) {
-		return;
+	declare CUIConfigMarker Marker = Private_GetMarker(G_MarkerId);
+	if (Marker != Null) {
+		Marker.HudVisibility = CUIConfigMarker::EHudVisibility::Never;
 	}
-	Marker.HudVisibility = CUIConfigMarker::EHudVisibility::Never;
+	declare CUIConfigMarker ShadowMarker = Private_GetMarker(G_ShadowVisibilityMarkerId);
+	if (ShadowMarker != Null) {
+		ShadowMarker.HudVisibility = CUIConfigMarker::EHudVisibility::Never;
+	}
 }
 
 Void Show() {
-	declare CUIConfigMarker Marker = Private_GetMarker();
-	if (Marker == Null) {
-		return;
+	declare CUIConfigMarker Marker = Private_GetMarker(G_MarkerId);
+	if (Marker != Null) {
+		Marker.HudVisibility = CUIConfigMarker::EHudVisibility::Always;
 	}
-	Marker.HudVisibility = CUIConfigMarker::EHudVisibility::Always;
+	declare CUIConfigMarker ShadowMarker = Private_GetMarker(G_ShadowVisibilityMarkerId);
+	if (ShadowMarker != Null) {
+		ShadowMarker.HudVisibility = CUIConfigMarker::EHudVisibility::WhenInFrustum;
+	}
 }
 
 // Lifecycle

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
@@ -26,11 +26,9 @@ Text GetManialink() {
 	return """<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <manialink version="3" name="{{{ C_LayerName }}}">
 
-	<frame z-index="2">
-		<frame id="{{{ C_FrameId_ShadowVisibilityMarker }}}" hidden="1"></frame>
-	</frame>
+	<frame id="{{{ C_FrameId_ShadowVisibilityMarker }}}"></frame>
 
-	<frame z-index="3"> <!-- Display flag marker over other markers (highest z-index) -->
+	<frame z-index="2"> <!-- Display flag marker over other markers (highest z-index) -->
 		<frame id="{{{ C_FrameId }}}" scale="0.9" hidden="1"> <!-- Initialize as hidden; Markers will show it automatically -->
 			<frame id="botom-align-offset" pos="0 5"> <!-- Flag icon height / 2 -->
 				<quad id="flag-shadow" pos="0 -5" z-index="-2" size="1 1" halign="center" valign="center" style="Bgs1InRace" substyle="BgShadow" hidden="1"/>
@@ -80,8 +78,6 @@ Text GetManialink() {
 #Const C_HeightIndicatorThreshold 7. // Less than one block (8m) to prevent potential flickering on one block height differences
 #Const C_FlagIconOffset -1.
 #Const C_DropGaugeSize 12.
-#Const C_FlagShadowFadeDistance_Near 0.
-#Const C_FlagShadowFadeDistance_Far 3.
 #Const C_FlagShadowScale_Base 250.
 #Const C_FlagShadowScale_Max 50.
 #Const C_FlagShadowHeightRatio_Max 0.7

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
@@ -144,30 +144,35 @@ Void Init() {
 	G_FlagMarker.DropGauge = DropGauge;
 }
 
-Void Update() {
+Void UpdateFlagColor() {
+	declare netread K_Net_Flag FlagRush_Net_Flag for Teams[0] = K_Net_Flag{};
+	G_FlagMarker.FlagIcon.IconQuad.Colorize = GetTeamMidColor(FlagRush_Net_Flag.Location.Player.Clan); // Clan will be 0 (neutral) if not carried
+}
+
+Void UpdateDistanceIndicators() {
 	declare netread K_Net_Flag FlagRush_Net_Flag for Teams[0] = K_Net_Flag{};
 
-	// Color
-	G_FlagMarker.FlagIcon.IconQuad.Colorize = GetTeamMidColor(FlagRush_Net_Flag.Location.Player.Clan); // Clan will be 0 (neutral) if not carried
-
-	// Distance and Height indicators
-	if (GUIPlayer == Null || FlagRush_Net_Flag.Location.Player.Login == GUIPlayer.User.Login) { // Not on a player
+	if (GUIPlayer == Null || FlagRush_Net_Flag.Location.Player.Login == GUIPlayer.User.Login) {
 		G_FlagMarker.DistanceLabel.Hide();
 		G_FlagMarker.HeightIndicator.UpQuad.Hide();
 		G_FlagMarker.HeightIndicator.DownQuad.Hide();
 		G_FlagMarker.FlagIcon.Frame.RelativePosition_V3.Y = 0.;
-	} else { // Playing or spectating a player
+	} else { // Playing or spectating a non-carrier player
 		declare Vec3 Displacement = FlagRush_Net_Flag.Location.Position - GUIPlayer.Position;
-		G_FlagMarker.DistanceLabel.Value = ML::TruncInteger(ML::Length(Displacement)) ^ "m";
+		declare Real Distance = ML::Length(Displacement);
+		G_FlagMarker.DistanceLabel.Value = ML::TruncInteger(Distance) ^ "m";
 		G_FlagMarker.FlagIcon.Frame.RelativePosition_V3.Y = C_FlagIconOffset;
 		G_FlagMarker.DistanceLabel.Show();
 
 		G_FlagMarker.HeightIndicator.UpQuad.Visible = Displacement.Y > C_HeightIndicatorThreshold;
 		G_FlagMarker.HeightIndicator.DownQuad.Visible = Displacement.Y < -C_HeightIndicatorThreshold;
 	}
+}
 
-	// Lock
+Void UpdateLock() {
+	declare netread K_Net_Flag FlagRush_Net_Flag for Teams[0] = K_Net_Flag{};
 	declare Boolean DisplayLock = False;
+
 	if (FlagRush_Net_Flag.Lock.Timer.Until > ArenaNow) {
 		declare Boolean LockedForAll = FlagRush_Net_Flag.Lock.Clan == 0 && FlagRush_Net_Flag.Lock.Player.Login == "";
 		declare Boolean LockedForClan = FlagRush_Net_Flag.Lock.Clan > 0;
@@ -197,9 +202,12 @@ Void Update() {
 		G_FlagMarker.Lock.Gauge.LeftQuad.Visible = GaugeProgress < 0.5;
 	}
 	G_FlagMarker.Lock.Frame.Visible = DisplayLock;
+}
 
-	// Drop gauge
+Void UpdateDropGauge() {
+	declare netread K_Net_Flag FlagRush_Net_Flag for Teams[0] = K_Net_Flag{};
 	declare Boolean DisplayDropGauge = FlagRush_Net_Flag.Drop.Timer.Until > ArenaNow;
+
 	if (DisplayDropGauge) {
 		declare Real GaugeProgress = Progress(FlagRush_Net_Flag.Drop.Timer.Since, FlagRush_Net_Flag.Drop.Timer.Until, ArenaNow);
 		G_FlagMarker.DropGauge.Frame.Size.Y = (1 - GaugeProgress) * C_DropGaugeSize;
@@ -208,14 +216,16 @@ Void Update() {
 }
 
 main() {
-
 	Init();
 	while(True) {
 		yield;
 		if (!G_FlagMarker.Frame.Visible || !Page.MainFrame.Visible) {
 			continue;
 		}
-		Update();
+		UpdateFlagColor();
+		UpdateDistanceIndicators();
+		UpdateLock();
+		UpdateDropGauge();
 	}
 }
 	--></script>


### PR DESCRIPTION
- Makes flag marker _practically_ bottom aligned, for better visibility when on player
- Adds fake pseudo 3D shadow below the flag icon when in dropped state