### PR TITLE
Check player spawn status for out of bounds triggers in warmup

### DIFF
--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -280,7 +280,7 @@ foreach (Event in PendingEvents) {
 		}
 		case CSmModeEvent::EType::OnPlayerTriggersWaypoint: {
 			// Player might have left in the same server frame, causing Player to be Null
-			if (Event.Player != Null && FlagRush_Map::IsOutOfBoundsTrigger(Event.Landmark)) {
+			if (Event.Player != Null && FlagRush_Map::IsOutOfBoundsTrigger(Event.Landmark) && Event.Player.SpawnStatus == CSmPlayer::ESpawnStatus::Spawned) {
 				Messages::PlayerOutOfBounds(Event.Player);
 				UnspawnPlayer(Event.Player);
 				declare Integer FlagRush_Warmup_UnspawnDate for Event.Player = Now;


### PR DESCRIPTION
We added this check in the past to the out of bounds triggers in the playloop, but didn't do so in the warmup. 🫠

Closes #281 