### PR TITLE
Remove setting S_UseTurns

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/BaseModes/FlagRushProgressionBase.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/BaseModes/FlagRushProgressionBase.Script.txt
@@ -68,7 +68,6 @@
 #Setting S_NbRoundsToWinMap									2 			as "Number of rounds to win a map"
 #Setting S_NbFlagsToWinRound								3				as "Number of flags scored to win a round"
 #Setting S_RoundTimeLimitSeconds						360 		as "Round Timelimit (seconds)"
-#Setting S_UseTurns													False 	as "<hidden>" // "Use turns (Reset after a player scores a flag)"
 #Setting S_UseOvertime											True 		as "Use overtime when round is tied"
 #Setting S_UseWarmUp												True		as "Use warm up"
 #Setting S_WarmUpWaitForApproval						False		as "<hidden>" // Wait for admin approval in warmup to continue (for competition situations)

--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -576,7 +576,6 @@ Void FlagCarrier_ScoreFlag() {
 	Player_ResetHandicaps(CarrierPlayer);
 	FlagRush_XmlRpc::Send_FlagScored(CarrierPlayer, Assist);
 	Flag_Reset(True);
-	if (S_UseTurns) MB_StopTurn();
 }
 
 // =========================================================== //

--- a/Mode settings.md
+++ b/Mode settings.md
@@ -14,7 +14,6 @@ These settings change how the general progression of a match works, i.e. how man
 | S_NbRoundsToWinMap            | Integer | 2             | Number of rounds to win a map. |
 | S_NbFlagsToWinRound           | Integer | 3             | Number of flags scored to win a round. Unlimited if <= 0.0 |
 | S_RoundTimeLimitSeconds       | Integer | 360           | Round timelimit in seconds. Unlimited if <= 0.0 |
-| S_UseTurns                    | Boolean | False         | Use turn based rounds. In turn based mode, all players will be reset after a flag has been scored. |
 | S_UseOvertime                 | Boolean | True          | Use overtime. If the match is tied when the timelimit runs out, the round will go into overtime until a team scores the next flag. |
 | S_UseWarmUp                   | Boolean | True          | Use warm up. At the beginning of the map players have to press the ready button for the match to start. If at least one player in each team is ready, a 60 second countdown starts after which the map starts. If all players are ready, a 5 second countdown start after which the map starts. |
 | S_WarmUpWaitForApproval       | Boolean | False         | Wait for the approval of an admin for the warmup countdowns to start. Requires usage of ModeCommandsUI. |
@@ -29,8 +28,8 @@ These settings change how the gameplay in a round behaves.
 | S_UseCrudeExtrapolation          | Boolean | True          | Determines the method that is used by clients to extrapolate player positions. Settings this setting to False has caused major desync issues in the past and is therefore not recommended. |
 | S_TrustClientSimu                | Boolean | True          | Whether to trust the physics simulation of the clients (players) or use serside physics simulation. Serverside physics simulation can cause teleporation on the client side, depending on their network connection to the server. |
 | S_UseReversedBases               | Boolean | False         | Changes the goals of the teams. If true, players have to score on their side of the map. |
-| S_RandomizeFlagSpawn             | Boolean | True          | Choose flag spawns at random (True) or always spawn the flag at the default flag spawn (False). The first flag of a round/turn will always spawn at the default flag spawn, independant from this setting. |
-| S_FlagInitialSpawnDelaySeconds   | Real    | 0.0           | Delay at the beginning of a round/turn in seconds during which the flag cannot be picked up from the initial flag spawn. |
+| S_RandomizeFlagSpawn             | Boolean | True          | Choose flag spawns at random (True) or always spawn the flag at the default flag spawn (False). The first flag of a round will always spawn at the default flag spawn, independant from this setting. |
+| S_FlagInitialSpawnDelaySeconds   | Real    | 0.0           | Delay at the beginning of a round in seconds during which the flag cannot be picked up from the initial flag spawn. |
 | S_FlagRespawnDelaySeconds        | Real    | 0.0           | Delay after the reset of the flag in seconds during which the flag cannot be picked up from the flag spawn. |
 | S_FlagDropStateDurationSeconds   | Real    | 8.0           | Duration in seconds that a dropped flag will stay dropped before being reset to a flagspawn. |
 | S_FlagStealResistDurationSeconds | Real    | 1.0           | Duration in seconds in which the flag cannot be stolen after picking it up. |


### PR DESCRIPTION
Remove unused settings `S_UseTurns` to reduce complexity.

This setting was added in the beginning when the future of the mode was unclear, but it was practically never used, as it doesn't fit into how the mode is played:
- Ending a turn after flag is scored brakes the flow and the dynamic of the round.
- The first flag of every round/turn is highly susceptible to "ping diff".