### PR TITLE
Remove setting S_UseReversedBases

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UI.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/FlagRush_UI.Script.txt
@@ -154,14 +154,6 @@ Void Net_SendModeScriptProgressionSettings(Integer NbMapsToWinMatch, Integer NbR
 	Net_FlagRush_NbFlagsToWinRound = NbFlagsToWinRound;
 }
 
-/**
- * Sends relevant round logic mode settings values to the clients via netwrite.
- */
-Void Net_SendModeScriptRoundLogicSettings(Boolean UseReversedBases) {
-	declare netwrite Boolean FlagRush_Net_UseReversedBases for Teams[0];
-	FlagRush_Net_UseReversedBases = UseReversedBases;
-}
-
 /* Lifecycle */
 
 Void Yield() {

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/MapMarkers.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/MapMarkers.Script.txt
@@ -111,7 +111,7 @@ Text GetManialink() {
 			G_DefaultFlagSpawnMarker.Order.Show();
 		}
 
-		Void UpdateBaseMarkers(Boolean Reversed) {
+		Void UpdateBaseMarkers() {
 			declare Integer UIClan = 0;
 			if (GUIPlayer != Null) {
 				UIClan = GUIPlayer.CurrentClan;
@@ -120,16 +120,8 @@ Text GetManialink() {
 			}
 
 			foreach (Clan => BaseMarkers in G_TeamBaseMarkers) {
-				declare Boolean ShowDefenseIcon;
-				declare Vec3 Color;
-				if (Reversed) {
-					Color = GetTeamMidColor(3 - Clan); // Color of opponent clan
-					ShowDefenseIcon = UIClan == 0 || Clan != UIClan;
-				} else {
-					Color = GetTeamMidColor(Clan);
-					ShowDefenseIcon = UIClan == 0 || Clan == UIClan;
-				}
-
+				declare Boolean ShowDefenseIcon = UIClan == 0 || Clan == UIClan;
+				declare Vec3 Color = GetTeamMidColor(Clan);
 				foreach (BaseMarker in BaseMarkers) {
 					BaseMarker.Icon.TextColor = Color;
 					if (ShowDefenseIcon) {
@@ -143,10 +135,9 @@ Text GetManialink() {
 
 		main() {
 			Init();
-			declare netread Boolean FlagRush_Net_UseReversedBases for Teams[0] = False;
 			while(True) {
 				yield;
-				UpdateBaseMarkers(FlagRush_Net_UseReversedBases);
+				UpdateBaseMarkers();
 			}
 		}
 	--></script>

--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -71,7 +71,6 @@
 #Setting S_TrustClientSimu									True		as "<hidden>"
 
 // Gameplay
-#Setting S_UseReversedBases									False 	as "<hidden>" // Switch team bases
 #Setting S_RandomizeFlagSpawn								True 		as "<hidden>" // Randomize flag spawn location
 #Setting S_FlagInitialSpawnDelaySeconds			0. 			as "<hidden>" // Initial flag spawn delay (seconds)
 #Setting S_FlagRespawnDelaySeconds					0. 			as "<hidden>" // Flag respawn delay (seconds)
@@ -111,8 +110,6 @@ declare Boolean FlagRush_Debug for This;
 FlagRush_Debug = C_Debug;
 
 UsePvPCollisions = S_UseCollisions;
-
-FlagRush_UI::Net_SendModeScriptRoundLogicSettings(S_UseReversedBases);
 ***
 
 ***LoadLibraries***
@@ -219,12 +216,7 @@ if (FlagCarrier != Null) {
 		declare Boolean IsTryingToScore = False; // Don't pass to team member if trying to score in same frame
 		foreach (Event in PendingEvents) {
 			declare Boolean IsFlagCarrierEvent = Event.Player == FlagCarrier;
-			declare Integer TargetBaseClan;
-			if (S_UseReversedBases) {
-				TargetBaseClan = FlagCarrier.CurrentClan;
-			} else {
-				TargetBaseClan = 3 - FlagCarrier.CurrentClan;
-			}
+			declare Integer TargetBaseClan = 3 - FlagCarrier.CurrentClan;
 			declare Boolean IsOpponentBaseEvent = Event.Type == CSmModeEvent::EType::OnPlayerTriggersWaypoint && FlagRush_Map::IsBase(Event.Landmark, TargetBaseClan);
 			if (IsFlagCarrierEvent && IsOpponentBaseEvent) {
 				IsTryingToScore = True;
@@ -346,12 +338,6 @@ if (FlagRush_PreviousSettings_ForceEnabledVehiclesCsv != S_ForceEnabledVehiclesC
 declare Boolean TrustClientSimuChanged = SettingTracker::HasChanged(S_TrustClientSimu, "S_TrustClientSimu");
 declare Boolean UseCrudeExtrapolationChanged = SettingTracker::HasChanged(S_UseCrudeExtrapolation, "S_UseCrudeExtrapolation");
 if (TrustClientSimuChanged || UseCrudeExtrapolationChanged) {
-	RestartTurn = True;
-}
-
-declare Boolean UseReversedBasesChanged = SettingTracker::HasChanged(S_UseReversedBases, "S_UseReversedBases");
-if (UseReversedBasesChanged) {
-	FlagRush_UI::Net_SendModeScriptRoundLogicSettings(S_UseReversedBases);
 	RestartTurn = True;
 }
 
@@ -637,12 +623,7 @@ Void OnPlayerTriggersWaypoint(CSmPlayer Player, CMapLandmark Landmark) {
 	} else if (Flag::Get().Location.LandmarkId == Landmark.Id && !Flag::IsLockedForPlayer(Player)) {
 		Player_PickUpFlag(Player);
 	} else if (Player == Flag::GetPlayer()){
-		declare Integer TargetBaseClan;
-		if (S_UseReversedBases) {
-			TargetBaseClan = Player.CurrentClan;
-		} else {
-			TargetBaseClan = 3 - Player.CurrentClan;
-		}
+		declare Integer TargetBaseClan = 3 - Player.CurrentClan;
 		if (FlagRush_Map::IsBase(Landmark, TargetBaseClan)) {
 			FlagCarrier_ScoreFlag();
 		}

--- a/Mode settings.md
+++ b/Mode settings.md
@@ -28,7 +28,6 @@ These settings change how the gameplay in a round behaves.
 | -------------------------------- | ------- | ------------- | ----------- |
 | S_UseCrudeExtrapolation          | Boolean | True          | Determines the method that is used by clients to extrapolate player positions. Settings this setting to False has caused major desync issues in the past and is therefore not recommended. |
 | S_TrustClientSimu                | Boolean | True          | Whether to trust the physics simulation of the clients (players) or use serside physics simulation. Serverside physics simulation can cause teleporation on the client side, depending on their network connection to the server. |
-| S_UseReversedBases               | Boolean | False         | Changes the goals of the teams. If true, players have to score on their side of the map. |
 | S_RandomizeFlagSpawn             | Boolean | True          | Choose flag spawns at random (True) or always spawn the flag at the default flag spawn (False). The first flag of a round/turn will always spawn at the default flag spawn, independant from this setting. |
 | S_FlagInitialSpawnDelaySeconds   | Real    | 0.0           | Delay at the beginning of a round/turn in seconds during which the flag cannot be picked up from the initial flag spawn. |
 | S_FlagRespawnDelaySeconds        | Real    | 0.0           | Delay after the reset of the flag in seconds during which the flag cannot be picked up from the flag spawn. |


### PR DESCRIPTION
Remove unused settings S_UseReversedBases to reduce complexity.

This setting was added in the beginning when the future of the mode was unclear, but it was practically never used, as it doesn't fit into how the mode is played:

- Attacking your own base is too easy, as the defending side has no way of getting there quickly
- This is especially problematic if a defender crashes