### PR TITLE
Remove settings flag spawn delays

### DIFF
--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/Flag.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/Flag.Script.txt
@@ -291,6 +291,12 @@ Void RemoveDropTimer() {
 	Net_Update();
 }
 
+Void Reset() {
+	G_Flag = K_Flag{};
+	SetUnspawned();
+	Net_Update();
+}
+
 // Lifecycle
 
 Void Yield() {
@@ -305,10 +311,9 @@ Void Yield() {
 }
 
 Void Unload() {
+	Reset();
 }
 
 Void Load() {
-	G_Flag = K_Flag{};
-	SetUnspawned();
-	Net_Update();
+	Unload();
 }

--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -73,7 +73,6 @@
 // Gameplay
 #Setting S_UseReversedBases									False 	as "<hidden>" // Switch team bases
 #Setting S_RandomizeFlagSpawn								True 		as "<hidden>" // Randomize flag spawn location
-#Setting S_FlagRespawnDelaySeconds					0. 			as "<hidden>" // Flag respawn delay (seconds)
 #Setting S_FlagDropStateDurationSeconds			8. 			as "<hidden>" // Flag drop state duration (seconds)
 #Setting S_FlagStealResistDurationSeconds		1. 			as "<hidden>" // Flag steal resistance (seconds)
 #Setting S_FlagSameTeamSteal								True		as "<hidden>" // Team flag steal
@@ -143,7 +142,7 @@ FlagRush_VehicleSelection::SetEnabledVehicles(Vehicle_GetEnabled());
 ***StartTurn***
 ***
 declare CMapLandmark FlagSpawn = FlagRush_Map::GetDefaultFlagSpawn();
-Flag::Load();
+Flag::Reset();
 Flag::SetAtLandmark(FlagSpawn);
 FlagMarker::Update();
 
@@ -420,8 +419,8 @@ Void Flag_Reset(Boolean Silent) {
 	declare CMapLandmark FlagSpawn;
 	if (!S_RandomizeFlagSpawn) FlagSpawn = FlagRush_Map::GetDefaultFlagSpawn();
 	else FlagSpawn = FlagRush_Map::GetRandomFlagSpawn();
+	Flag::Reset();
 	Flag::SetAtLandmark(FlagSpawn);
-	Flag::Lock(Now + ML::NearestInteger(S_FlagRespawnDelaySeconds * 1000));
 	FlagMarker::Update();
 	FlagRush_XmlRpc::Send_FlagReset();
 }

--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -73,7 +73,6 @@
 // Gameplay
 #Setting S_UseReversedBases									False 	as "<hidden>" // Switch team bases
 #Setting S_RandomizeFlagSpawn								True 		as "<hidden>" // Randomize flag spawn location
-#Setting S_FlagInitialSpawnDelaySeconds			0. 			as "<hidden>" // Initial flag spawn delay (seconds)
 #Setting S_FlagRespawnDelaySeconds					0. 			as "<hidden>" // Flag respawn delay (seconds)
 #Setting S_FlagDropStateDurationSeconds			8. 			as "<hidden>" // Flag drop state duration (seconds)
 #Setting S_FlagStealResistDurationSeconds		1. 			as "<hidden>" // Flag steal resistance (seconds)
@@ -144,10 +143,8 @@ FlagRush_VehicleSelection::SetEnabledVehicles(Vehicle_GetEnabled());
 ***StartTurn***
 ***
 declare CMapLandmark FlagSpawn = FlagRush_Map::GetDefaultFlagSpawn();
-declare Integer FlagSpawnDate = Now + ML::NearestInteger(S_FlagInitialSpawnDelaySeconds * 1000);
 Flag::Load();
 Flag::SetAtLandmark(FlagSpawn);
-Flag::Lock(FlagSpawnDate);
 FlagMarker::Update();
 
 foreach (Player in Players) {

--- a/Mode settings.md
+++ b/Mode settings.md
@@ -30,7 +30,6 @@ These settings change how the gameplay in a round behaves.
 | S_TrustClientSimu                | Boolean | True          | Whether to trust the physics simulation of the clients (players) or use serside physics simulation. Serverside physics simulation can cause teleporation on the client side, depending on their network connection to the server. |
 | S_UseReversedBases               | Boolean | False         | Changes the goals of the teams. If true, players have to score on their side of the map. |
 | S_RandomizeFlagSpawn             | Boolean | True          | Choose flag spawns at random (True) or always spawn the flag at the default flag spawn (False). The first flag of a round/turn will always spawn at the default flag spawn, independant from this setting. |
-| S_FlagRespawnDelaySeconds        | Real    | 0.0           | Delay after the reset of the flag in seconds during which the flag cannot be picked up from the flag spawn. |
 | S_FlagDropStateDurationSeconds   | Real    | 8.0           | Duration in seconds that a dropped flag will stay dropped before being reset to a flagspawn. |
 | S_FlagStealResistDurationSeconds | Real    | 1.0           | Duration in seconds in which the flag cannot be stolen after picking it up. |
 | S_FlagSameTeamSteal              | Boolean | True          | Whether or not teammates can steal the flag from the flag carrier. |

--- a/Mode settings.md
+++ b/Mode settings.md
@@ -30,7 +30,6 @@ These settings change how the gameplay in a round behaves.
 | S_TrustClientSimu                | Boolean | True          | Whether to trust the physics simulation of the clients (players) or use serside physics simulation. Serverside physics simulation can cause teleporation on the client side, depending on their network connection to the server. |
 | S_UseReversedBases               | Boolean | False         | Changes the goals of the teams. If true, players have to score on their side of the map. |
 | S_RandomizeFlagSpawn             | Boolean | True          | Choose flag spawns at random (True) or always spawn the flag at the default flag spawn (False). The first flag of a round/turn will always spawn at the default flag spawn, independant from this setting. |
-| S_FlagInitialSpawnDelaySeconds   | Real    | 0.0           | Delay at the beginning of a round/turn in seconds during which the flag cannot be picked up from the initial flag spawn. |
 | S_FlagRespawnDelaySeconds        | Real    | 0.0           | Delay after the reset of the flag in seconds during which the flag cannot be picked up from the flag spawn. |
 | S_FlagDropStateDurationSeconds   | Real    | 8.0           | Duration in seconds that a dropped flag will stay dropped before being reset to a flagspawn. |
 | S_FlagStealResistDurationSeconds | Real    | 1.0           | Duration in seconds in which the flag cannot be stolen after picking it up. |


### PR DESCRIPTION
Remove unused settings S_FlagInitialSpawnDelaySeconds and S_FlagRespawnDelaySeconds to reduce complexity.

These settings were added in the beginning when the future of the mode was unclear, but it was practically never used, as it doesn't fit into how the mode is played:

- Setting locks on flag when they spawn at landmark causes players to set up next to them, causing either "ping diff" issues or a random player to get the flag when multiple players cross the spawn in the same yield as the lock ends.
- Having players wait for the flag lock to expire breaks the flow and dynamics of a round.