### PR TITLE
Remove setting randomize flag spawns

### DIFF
--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -72,7 +72,6 @@
 
 // Gameplay
 #Setting S_UseReversedBases									False 	as "<hidden>" // Switch team bases
-#Setting S_RandomizeFlagSpawn								True 		as "<hidden>" // Randomize flag spawn location
 #Setting S_FlagInitialSpawnDelaySeconds			0. 			as "<hidden>" // Initial flag spawn delay (seconds)
 #Setting S_FlagRespawnDelaySeconds					0. 			as "<hidden>" // Flag respawn delay (seconds)
 #Setting S_FlagDropStateDurationSeconds			8. 			as "<hidden>" // Flag drop state duration (seconds)
@@ -420,10 +419,7 @@ CSmPlayer GetFirstCollidingPlayer_OpponentPriority(CSmPlayer ReferencePlayer) {
 Void Flag_Reset(Boolean Silent) {
 	if (!Silent) Messages::FlagReset(C_Duration_EventMessage);
 
-	declare CMapLandmark FlagSpawn;
-	if (!S_RandomizeFlagSpawn) FlagSpawn = FlagRush_Map::GetDefaultFlagSpawn();
-	else FlagSpawn = FlagRush_Map::GetRandomFlagSpawn();
-	Flag::SetAtLandmark(FlagSpawn);
+	Flag::SetAtLandmark(FlagRush_Map::GetRandomFlagSpawn());
 	Flag::Lock(Now + ML::NearestInteger(S_FlagRespawnDelaySeconds * 1000));
 	FlagMarker::Update();
 	FlagRush_XmlRpc::Send_FlagReset();

--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -402,7 +402,7 @@ Void Flag_Reset(Boolean Silent) {
 	if (!Silent) Messages::FlagReset(C_Duration_EventMessage);
 
 	Flag::Reset();
-	Flag::SetAtLandmark(FlagSpawn);
+	Flag::SetAtLandmark(FlagRush_Map::GetRandomFlagSpawn());
 	FlagMarker::Update();
 	FlagRush_XmlRpc::Send_FlagReset();
 }

--- a/Mode settings.md
+++ b/Mode settings.md
@@ -29,7 +29,6 @@ These settings change how the gameplay in a round behaves.
 | S_UseCrudeExtrapolation          | Boolean | True          | Determines the method that is used by clients to extrapolate player positions. Settings this setting to False has caused major desync issues in the past and is therefore not recommended. |
 | S_TrustClientSimu                | Boolean | True          | Whether to trust the physics simulation of the clients (players) or use serside physics simulation. Serverside physics simulation can cause teleporation on the client side, depending on their network connection to the server. |
 | S_UseReversedBases               | Boolean | False         | Changes the goals of the teams. If true, players have to score on their side of the map. |
-| S_RandomizeFlagSpawn             | Boolean | True          | Choose flag spawns at random (True) or always spawn the flag at the default flag spawn (False). The first flag of a round/turn will always spawn at the default flag spawn, independant from this setting. |
 | S_FlagInitialSpawnDelaySeconds   | Real    | 0.0           | Delay at the beginning of a round/turn in seconds during which the flag cannot be picked up from the initial flag spawn. |
 | S_FlagRespawnDelaySeconds        | Real    | 0.0           | Delay after the reset of the flag in seconds during which the flag cannot be picked up from the flag spawn. |
 | S_FlagDropStateDurationSeconds   | Real    | 8.0           | Duration in seconds that a dropped flag will stay dropped before being reset to a flagspawn. |


### PR DESCRIPTION
Remove unused settings S_RandomizeFlagSpawns to reduce complexity.

This settings was added in the beginning when the future of the mode was unclear, but it was practically never used, as it doesn't fit into how the mode is played:

- Without random flag spawns, only the default flag spawn is used. All other flag spawns become unusable.
- Flag spawning becomes to predictable and camping flag spawns (after giving up defense or attack) becomes too easy.