### PR TITLE
Add Desert Vehicle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - Removed setting `S_FlagInitialSpawnDelaySeconds`.
 - Removed setting `S_FlagRespawnDelaySeconds`.
 - Removed setting `S_RandomizeFlagSpawn`.
-+ Add vehicle specific tunings for balancing with respective settings (`S_Tuning<Car><Tuning type>`, see [Mode settings](./Mode%20settings.md/#vehicle-tuning-settings)).
++ Added support for the new desert car.
++ Added vehicle specific tunings for balancing with respective settings (`S_Tuning<Car><Tuning type>`, see [Mode settings](./Mode%20settings.md/#vehicle-tuning-settings)).
 
 ### Bugs and crashes
 * Fixed division by zero error in flag marker layer.

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Map.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Map.Script.txt
@@ -74,7 +74,7 @@ FlagRush_Vehicle::K_Vehicle[] GetEnabledVehicles() {
 	declare metadata Text[] FlagRush_Meta_Vehicles for Map = [];
 	declare FlagRush_Vehicle::K_Vehicle[] EnabledVehicles;
 
-	for (VehicleId in FlagRush_Meta_Vehicles) {
+	foreach (VehicleId in FlagRush_Meta_Vehicles) {
 		if (FlagRush_Vehicle::IsValid(VehicleId)) {
 			EnabledVehicles.add(FlagRush_Vehicle::Get(VehicleId));
 		}
@@ -91,7 +91,7 @@ FlagRush_Vehicle::K_Vehicle[] GetEnabledVehicles() {
  * @see GetEnabledVehiclew
  */
 Boolean IsVehicleEnabled(Text VehicleId) {
-	for (Vehicle in GetEnabledVehicles()) {
+	foreach (Vehicle in GetEnabledVehicles()) {
 		if (Vehicle.Id == VehicleId) {
 			return True;
 		}

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Vehicle.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Vehicle.Script.txt
@@ -15,6 +15,7 @@
 #Const C_Vehicle_Stadium K_Vehicle{ Id = "stadium", Order = 0, ModelName = "CarSport"}
 #Const C_Vehicle_Snow K_Vehicle{ Id = "snow", Order = 1, ModelName = "CarSnow"}
 #Const C_Vehicle_Rally K_Vehicle{ Id = "rally", Order = 2, ModelName = "CarRally"}
+#Const C_Vehicle_Desert K_Vehicle{ Id = "desert", Order = 3, ModelName = "CarDesert"}
 
 #Const C_Tuning_Default K_Tuning{ Acceleration = 1.0, Adherence = 1.0, Control = 1.0 }
 
@@ -41,7 +42,7 @@ K_Vehicle[] Sort(K_Vehicle[] Vehicles) {
  * Returns a array of all vehicles that are known to the mode.
  */
 K_Vehicle[] GetAll() {
-	return [C_Vehicle_Stadium, C_Vehicle_Snow, C_Vehicle_Rally];
+	return [C_Vehicle_Stadium, C_Vehicle_Snow, C_Vehicle_Rally, C_Vehicle_Desert];
 }
 
 /**
@@ -135,7 +136,7 @@ Ident GetItemId(Text VehicleId) {
  */
 Void LoadItems() {
 	G_VehicleItems.clear();
-	for (Vehicle in GetAll()) {
+	foreach (Vehicle in GetAll()) {
 		G_VehicleItems[Vehicle.Id] = ItemList_Add(Vehicle.ModelName);
 	}
 }

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Vehicle.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/FlagRush_Vehicle.Script.txt
@@ -2,6 +2,8 @@
 	Text Id;
 	Integer Order;
 	Text ModelName;
+	Text DisplayName;
+	Text DisplayIcon;
 }
 
 #Struct K_Tuning {
@@ -11,11 +13,11 @@
 }
 
 // When adding vehicles, also add them to GetAll()
-#Const C_Vehicle_Invalid K_Vehicle{ Id = "", Order = -1, ModelName = "" }
-#Const C_Vehicle_Stadium K_Vehicle{ Id = "stadium", Order = 0, ModelName = "CarSport"}
-#Const C_Vehicle_Snow K_Vehicle{ Id = "snow", Order = 1, ModelName = "CarSnow"}
-#Const C_Vehicle_Rally K_Vehicle{ Id = "rally", Order = 2, ModelName = "CarRally"}
-#Const C_Vehicle_Desert K_Vehicle{ Id = "desert", Order = 3, ModelName = "CarDesert"}
+#Const C_Vehicle_Invalid K_Vehicle{ Id = "", Order = -1, ModelName = "", DisplayName = "Invalid", DisplayIcon = "?" }
+#Const C_Vehicle_Stadium K_Vehicle{ Id = "stadium", Order = 0, ModelName = "CarSport", DisplayName = "Stadium", DisplayIcon = "" }
+#Const C_Vehicle_Snow K_Vehicle{ Id = "snow", Order = 1, ModelName = "CarSnow", DisplayName = "Snow", DisplayIcon = "❄" }
+#Const C_Vehicle_Rally K_Vehicle{ Id = "rally", Order = 2, ModelName = "CarRally", DisplayName = "Rally", DisplayIcon = "" }
+#Const C_Vehicle_Desert K_Vehicle{ Id = "desert", Order = 3, ModelName = "CarDesert", DisplayName = "Desert", DisplayIcon = "" }
 
 #Const C_Tuning_Default K_Tuning{ Acceleration = 1.0, Adherence = 1.0, Control = 1.0 }
 
@@ -27,12 +29,12 @@ declare K_Tuning[Text] G_VehicleTunings;
  */
 K_Vehicle[] Sort(K_Vehicle[] Vehicles) {
 	declare K_Vehicle[Integer] VehicleMap;
-	for (Vehicle in Vehicles) {
+	foreach (Vehicle in Vehicles) {
 		VehicleMap[Vehicle.Order] = Vehicle;
 	}
 	VehicleMap = VehicleMap.sortkey();
 	declare K_Vehicle[] SortedVehicles;
-	for (Order => Vehicle in VehicleMap) {
+	foreach (Order => Vehicle in VehicleMap) {
 		SortedVehicles.add(Vehicle);
 	}
 	return SortedVehicles;
@@ -49,7 +51,7 @@ K_Vehicle[] GetAll() {
  * Gets the Vehicle struct for a given VehicleId.
  */
 K_Vehicle Get(Text VehicleId) {
-	for (Vehicle in GetAll()) {
+	foreach (Vehicle in GetAll()) {
 		if (Vehicle.Id == VehicleId) {
 			return Vehicle;
 		}
@@ -58,7 +60,7 @@ K_Vehicle Get(Text VehicleId) {
 }
 
 K_Vehicle Get(Ident _ModelId) {
-	for (VehicleId => ModelId in G_VehicleItems) {
+	foreach (VehicleId => ModelId in G_VehicleItems) {
 		if (ModelId == _ModelId) {
 			return Get(VehicleId);
 		}
@@ -70,7 +72,7 @@ K_Vehicle Get(Ident _ModelId) {
  * Check if a the given VehicleId is valid (known).
  */
 Boolean IsValid(Text VehicleId) {
-	for (Vehicle in GetAll()) {
+	foreach (Vehicle in GetAll()) {
 		if (Vehicle.Id == VehicleId) {
 			return True;
 		}

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
@@ -10,12 +10,14 @@
 
 #Const Vehicles::C_Vehicle_Snow as C_Vehicle_Snow
 #Const Vehicles::C_Vehicle_Rally as C_Vehicle_Rally
+#Const Vehicles::C_Vehicle_Desert as C_Vehicle_Desert
 
 // Boxes are adjusted to be slightly above the highest part of the respective model when on flat ground
 // Vertical 0.0 is not on the ground but slightly above player head; negative values not possible
 #Const C_Box_Player_Stadium		<0., 0., 0.>
 #Const C_Box_Player_Snow			<0., 0.4, 0.>
 #Const C_Box_Player_Rally 		<0., 0.25, 0.>
+#Const C_Box_Player_Desert 		<0., 0.25, 0.> // TODO: Adjust
 #Const C_Box_Landmark					<0., 0., 0.>
 #Const C_Box_Position					<0., 0., 0.>
 
@@ -329,6 +331,9 @@ Void Private_SetAtPlayer(CSmPlayer _Player) {
 		}
 		case Vehicles::GetItemId(C_Vehicle_Rally.Id): {
 			Marker.Box = C_Box_Player_Rally;
+		}
+		case Vehicles::GetItemId(C_Vehicle_Desert.Id): {
+			Marker.Box = C_Box_Player_Desert;
 		}
 		default: {
 			Marker.Box = C_Box_Player_Stadium;

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagMarker.Script.txt
@@ -17,7 +17,7 @@
 #Const C_Box_Player_Stadium		<0., 0., 0.>
 #Const C_Box_Player_Snow			<0., 0.4, 0.>
 #Const C_Box_Player_Rally 		<0., 0.25, 0.>
-#Const C_Box_Player_Desert 		<0., 0.25, 0.> // TODO: Adjust
+#Const C_Box_Player_Desert 		<0., 0.3, 0.>
 #Const C_Box_Landmark					<0., 0., 0.>
 #Const C_Box_Position					<0., 0., 0.>
 

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagPossessionIndicator.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/FlagPossessionIndicator.Script.txt
@@ -36,7 +36,7 @@ CMlQuad[] GetQuads() {
 
 Void Animate(Real _Opacity) {
 	declare Target = "<elem opacity=\"" ^ _Opacity ^ "\"/>";
-	for (Control in GetQuads()) {
+	foreach (Control in GetQuads()) {
 		AnimMgr.Flush(Control);
 		AnimMgr.Add(Control, Target, C_FadeAnimDuration, C_FadeAnimEasing);
 	}

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/VehicleSelection.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/VehicleSelection.Script.txt
@@ -8,26 +8,12 @@
 
 #Const C_LayerName "FlagRush_VehicleSelection"
 
-#Struct K_UIVehicleButtonParameter {
-	Text Label;
-	Text Icon;
-}
-
-// Keys should be same a FlagRush_Vehicle::C_Vehicle_*.Id
-#Const C_UIVehicleButtonParameters [
-	"stadium" => K_UIVehicleButtonParameter{Label = "Stadium", Icon = ""},
-	"snow" => K_UIVehicleButtonParameter{Label = "Snow", Icon = "❄"},
-	"rally" => K_UIVehicleButtonParameter{Label = "Rally", Icon = ""},
-	"desert" => K_UIVehicleButtonParameter{Label = "Desert", Icon = ""}
-]
-
 declare FlagRush_Vehicle::K_Vehicle[] G_EnabledVehicles;
 
 Text GetManialink() {
 	declare Text VehicleFrameInstances;
-	for (Index => Vehicle in G_EnabledVehicles) {
-		declare K_UIVehicleButtonParameter Parameters = C_UIVehicleButtonParameters.get(Vehicle.Id, K_UIVehicleButtonParameter{});
-		VehicleFrameInstances ^= """<frameinstance modelid="vehicle-option" id="vehicle-option-{{{ Vehicle.Id }}}" pos="{{{ 6 + Index * 13 }}} 0" data-name="{{{ Parameters.Label }}}" data-icon="{{{ Parameters.Icon }}}" data-id="{{{ Vehicle.Id }}}" />""";
+	foreach (Index => Vehicle in G_EnabledVehicles) {
+		VehicleFrameInstances ^= """<frameinstance modelid="vehicle-option" id="vehicle-option-{{{ Vehicle.Id }}}" pos="{{{ 6 + Index * 13 }}} 0" data-name="{{{ Vehicle.DisplayName }}}" data-icon="{{{ Vehicle.DisplayIcon }}}" data-id="{{{ Vehicle.Id }}}" />""";
 	}
 
 	return """
@@ -175,7 +161,7 @@ Text GetManialink() {
 FlagRush_Vehicle::K_Vehicle GetSlectedVehicle(CSmPlayer Player) {
 	declare CUIConfig UI = UIManager.GetUI(Player);
 	declare netread Text Net_FlagRush_SelectedVehicleId for UI = "";
-	for (Vehicle in G_EnabledVehicles) {
+	foreach (Vehicle in G_EnabledVehicles) {
 		if (Vehicle.Id == Net_FlagRush_SelectedVehicleId) {
 			return Vehicle;
 		}

--- a/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/VehicleSelection.Script.txt
+++ b/DedicatedServer/Scripts/Libs/Zrx/ModeLibs/FlagRush/UI/Modules/VehicleSelection.Script.txt
@@ -17,7 +17,8 @@
 #Const C_UIVehicleButtonParameters [
 	"stadium" => K_UIVehicleButtonParameter{Label = "Stadium", Icon = ""},
 	"snow" => K_UIVehicleButtonParameter{Label = "Snow", Icon = "❄"},
-	"rally" => K_UIVehicleButtonParameter{Label = "Rally", Icon = ""}
+	"rally" => K_UIVehicleButtonParameter{Label = "Rally", Icon = ""},
+	"desert" => K_UIVehicleButtonParameter{Label = "Desert", Icon = ""}
 ]
 
 declare FlagRush_Vehicle::K_Vehicle[] G_EnabledVehicles;

--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -64,6 +64,7 @@
 #Const FlagRush_Vehicle::C_Vehicle_Stadium as C_Vehicle_Stadium
 #Const FlagRush_Vehicle::C_Vehicle_Snow as C_Vehicle_Snow
 #Const FlagRush_Vehicle::C_Vehicle_Rally as C_Vehicle_Rally
+#Const FlagRush_Vehicle::C_Vehicle_Desert as C_Vehicle_Desert
 
 // ======== //
 // Settings //
@@ -98,6 +99,9 @@
 #Setting S_TuningRallyAcceleration					0.7 		as "<hidden>"
 #Setting S_TuningRallyAdherence							1.0 		as "<hidden>"
 #Setting S_TuningRallyControl								1.0 		as "<hidden>"
+#Setting S_TuningDesertAcceleration					1.0 		as "<hidden>" // TODO: Tune
+#Setting S_TuningDesertAdherence						1.0 		as "<hidden>"
+#Setting S_TuningDesertControl							1.0 		as "<hidden>"
 
 // ======== //
 // Commands //
@@ -382,6 +386,12 @@ if (VehicleTuningChanged) {
 	RallyTuning.Adherence =				S_TuningRallyAdherence;
 	RallyTuning.Control =					S_TuningRallyControl;
 	FlagRush_Vehicle::SetTuning(C_Vehicle_Rally.Id, RallyTuning);
+
+	declare FlagRush_Vehicle::K_Tuning DesertTuning = FlagRush_Vehicle::C_Tuning_Default;
+	DesertTuning.Acceleration =		S_TuningDesertAcceleration;
+	DesertTuning.Adherence =			S_TuningDesertAdherence;
+	DesertTuning.Control =				S_TuningDesertControl;
+	FlagRush_Vehicle::SetTuning(C_Vehicle_Desert.Id, DesertTuning);
 
 	RestartTurn = True;
 }

--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -99,7 +99,7 @@
 #Setting S_TuningRallyAcceleration					0.7 		as "<hidden>"
 #Setting S_TuningRallyAdherence							1.0 		as "<hidden>"
 #Setting S_TuningRallyControl								1.0 		as "<hidden>"
-#Setting S_TuningDesertAcceleration					1.0 		as "<hidden>" // TODO: Tune
+#Setting S_TuningDesertAcceleration					0.66 		as "<hidden>"
 #Setting S_TuningDesertAdherence						1.0 		as "<hidden>"
 #Setting S_TuningDesertControl							1.0 		as "<hidden>"
 

--- a/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
+++ b/DedicatedServer/Scripts/Modes/TrackMania/FlagRush.Script.txt
@@ -329,7 +329,7 @@ if (FlagRush_PreviousSettings_ForceEnabledVehiclesCsv != S_ForceEnabledVehiclesC
 	// Note: Cannot use functions like Vehicle_GetEnabled or globals in Yield due to ordering after compilation
 	declare FlagRush_Vehicle::K_Vehicle[] FlagRush_ForceEnabledVehicles for This = [];
 	FlagRush_ForceEnabledVehicles.clear();
-	for (CsvEntry in TL::Split(",", S_ForceEnabledVehiclesCsv)) {
+	foreach (CsvEntry in TL::Split(",", S_ForceEnabledVehiclesCsv)) {
 		declare Text VehicleId = TL::ToLowerCase(TL::Trim(CsvEntry));
 		if (FlagRush_Vehicle::IsValid(VehicleId)) {
 			FlagRush_ForceEnabledVehicles.add(FlagRush_Vehicle::Get(VehicleId));
@@ -416,7 +416,7 @@ FlagRush_Vehicle::K_Vehicle[] Vehicle_GetEnabled() {
 
 Boolean Vehicle_IsEnabled(FlagRush_Vehicle::K_Vehicle Vehicle) {
 	declare FlagRush_Vehicle::K_Vehicle[] Vehicles = Vehicle_GetEnabled();
-	for (EnabledVehicle in Vehicles) {
+	foreach (EnabledVehicle in Vehicles) {
 		if (Vehicle.Id == EnabledVehicle.Id) {
 			return True;
 		}

--- a/GameClient/Scripts/MapTypes/FlagRushArena.Script.txt
+++ b/GameClient/Scripts/MapTypes/FlagRushArena.Script.txt
@@ -128,12 +128,12 @@ Text GetMapConfigWindowManialink() {
 	</framemodel>
 
 	<framemodel id="vehiclebutton" class="vehiclebutton">
-		<label id="button" pos="0 0" size="20 5" text="Vehicle___" style="CardButtonMediumS" valign="center" halign="center" scriptevents="1"/>
+		<label id="button" pos="0 0" size="20 5" text="Vehicle___" style="CardButtonMedium" valign="center" halign="center" scriptevents="1"/>
 		<quad id="checkbox" pos="10 0" size="5 5" valign="center" halign="center" style="UICommon64_1" substyle="CheckboxCircle_light"/>
 	</framemodel>
 
-	<frame pos="0 45">
-		<quad pos="0 0" z-index="-2" size="100 90" style="UICommon64_1" substyle="BgFrame1"  colorize="{{{ Stylesheet::C_ColorHex6_GreenThree }}}" halign="center" valign="top" />
+	<frame pos="0 50">
+		<quad pos="0 0" z-index="-2" size="100 100" style="UICommon64_1" substyle="BgFrame1"  colorize="{{{ Stylesheet::C_ColorHex6_GreenThree }}}" halign="center" valign="top" />
 		<quad pos="0 0" z-index="-1" size="100 10" style="UICommon64_1" substyle="BgFrame1"  colorize="{{{ Stylesheet::C_ColorHex6_GreenTwo }}}" halign="center" valign="top" />
 		<label pos="0 -5.25" z-index="0" size="90 8" text="$iFlagRush Settings" halign="center" valign="center2" textfont="GameFontBlack" textsize="3" />
 
@@ -146,13 +146,14 @@ Text GetMapConfigWindowManialink() {
 
 		<frame id="vehicles" pos="0 -60">
 			<label size="45 5" text="$iVehicles:" halign="center" valign="center2" textfont="GameFontSemiBold" textsize="3" z-index="1" textcolor="FFF"/>
-			<frameinstance modelid="vehiclebutton" pos="-30 -7.5" id="{{{ C_VehicleId_Stadium }}}" data-label="Stadium"/>
-			<frameinstance modelid="vehiclebutton" pos="0 -7.5" id="{{{ C_VehicleId_Snow }}}" data-label="Snow"/>
-			<frameinstance modelid="vehiclebutton" pos="30 -7.5" id="{{{ C_VehicleId_Rally }}}" data-label="Rally"/>
-			<label size="70 5" pos="0 -14" text=" $iThe gamemode defaults to all vehicles being enabled if no selection is made here." halign="center" valign="center2" textfont="GameFontRegular" textsize="0.5" z-index="1" textcolor="FFF"/>
+			<frameinstance modelid="vehiclebutton" pos="-20 -7.5" id="{{{ C_VehicleId_Stadium }}}" data-label="Stadium"/>
+			<frameinstance modelid="vehiclebutton" pos="20 -7.5" id="{{{ C_VehicleId_Snow }}}" data-label="Snow"/>
+			<frameinstance modelid="vehiclebutton" pos="-20 -17.5" id="{{{ C_VehicleId_Rally }}}" data-label="Rally"/>
+			<frameinstance modelid="vehiclebutton" pos="20 -17.5" id="{{{ C_VehicleId_Desert }}}" data-label="Desert"/>
+			<label size="70 5" pos="0 -24" text=" $iThe gamemode defaults to all vehicles being enabled if no selection is made here." halign="center" valign="center2" textfont="GameFontRegular" textsize="0.5" z-index="1" textcolor="FFF"/>
 		</frame>
 
-		<label id="close" pos="0 -82.5" z-index="0" size="20 5" text="Close" style="CardButtonMediumL" valign="center" halign="center" scriptevents="1"/>
+		<label id="close" pos="0 -92.5" z-index="0" size="20 5" text="Close" style="CardButtonMediumL" valign="center" halign="center" scriptevents="1"/>
 	</frame>
 
 
@@ -238,7 +239,7 @@ Text GetMapConfigWindowManialink() {
 
 		declare metadata Text[] FlagRush_Meta_Vehicles for Editor.Map = [];
 		Page.GetClassChildren("vehiclebutton", Page.MainFrame, True);
-		for (ButtonFrame in Page.GetClassChildren_Result) {
+		foreach (ButtonFrame in Page.GetClassChildren_Result) {
 			declare K_VehicleButton VehicleButton;
 			VehicleButton.Frame = ButtonFrame as CMlFrame;
 			VehicleButton.Button = (VehicleButton.Frame.GetFirstChild("button") as CMlLabel);
@@ -284,7 +285,7 @@ Text GetMapConfigWindowManialink() {
 									}
 								}
 							}
-							for (VehicleButton in G_VehicleButtons) {
+							foreach (VehicleButton in G_VehicleButtons) {
 								if (Event.Control == VehicleButton.Button) {
 									SendCustomEvent("{{{ C_UIEventType_ToggleVehicle }}}", [VehicleButton.Frame.ControlId]);
 								}

--- a/Mode settings.md
+++ b/Mode settings.md
@@ -57,6 +57,9 @@ These settings change vehicle characteristic for balancing.
 | S_TuningRallyAcceleration   | Real | 0.7           | Base acceleration coefficient for the rally car.         |
 | S_TuningRallyAdherence      | Real | 1.0           | Base adherence coefficient for the rally car.            |
 | S_TuningRallyControl        | Real | 1.0           | Base control (steering) coefficient for the rally car.   |
+| S_TuningDesertAcceleration  | Real | 0.7           | Base acceleration coefficient for the desert car.         |
+| S_TuningDesertAdherence     | Real | 1.0           | Base adherence coefficient for the desert car.            |
+| S_TuningDesertControl       | Real | 1.0           | Base control (steering) coefficient for the desert car.   |
 
 ## Team settings
 


### PR DESCRIPTION
Closes #301 

Preparation for the Desert car Update.
- Adds the Desert car to the list in FlagRush_Vehicles
- Moves the display name and icon from Vehicle_Selection to FlagRush_Vehicles to have all vehicle properties in a central place
- Adds a new box for the flag marker when on a desert car
- Adds desert car tuning settings
- Adds the desert car to the FlagRush configuration dialog in the editor
- Also changes some unrelated `for`s to `foreach` that I introduced when adding support for the other cars

Todo:
- [x] Adjust tuning to be in line with the other cars
- [x] Adjust marker box to be as close to the top of the car as possible